### PR TITLE
Fix `permission denied` git error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ parallel
 1. clone
 
 ```shell
-[~]>$ git clone git@github.com:MortezaBashsiz/CFScanner.git
+[~]>$ git clone https://github.com/MortezaBashsiz/CFScanner.git
 ```
 
 2. Change direcotry


### PR DESCRIPTION
Fix `permission denied` error while cloning repository with SSH. Changed clone URL to HTTPS.