### PR TITLE
Add a simple progress bar feature

### DIFF
--- a/scripts/cfFindIP.sh
+++ b/scripts/cfFindIP.sh
@@ -120,7 +120,7 @@ function fncCheckSubnet {
 	configPort="$7"
 	configPath="$8"
 	configServerName="$9"
-	osVersion="$10"
+	osVersion="${10}"
 	v2rayCommand="v2ray"
 	configDir="$scriptDir/../config"
 	# set proper command for linux

--- a/scripts/cfFindIP.sh
+++ b/scripts/cfFindIP.sh
@@ -92,20 +92,19 @@ function show_progress {
   current="$1"
   total="$2"
 
-  bar_size=$(tput cols)
+  bar_size="$(($(tput cols)-60))" # 65 cols for description characters
 
   # calculate the progress in percentage 
   percent=$(bc <<< "scale=$bar_percentage_scale; 100 * $current / $total" )
   # The number of done and todo characters
   done=$(bc <<< "scale=0; $bar_size * $percent / 100" )
-  todo=$(bc <<< "scale=0; $bar_size - $done - 60" ) # 60 cols for description characters
-
+  todo=$(bc <<< "scale=0; $bar_size - $done")
   # build the done and todo sub-bars
   done_sub_bar=$(printf "%${done}s" | tr " " "${bar_char_done}")
   todo_sub_bar=$(printf "%${todo}s" | tr " " "${bar_char_todo}")
 
   # output the bar
-  progressBar="Progress : [${done_sub_bar}${todo_sub_bar}] ${percent}% of total IPs.      " # Some end space for pretty formatting
+  progressBar="Progress : [${done_sub_bar}${todo_sub_bar}] ${percent}% of total IPs.         " # Some end space for pretty formatting
 }
 
 # Function fncCheckSubnet


### PR DESCRIPTION
I made a progress bar that can show progress of checked subnets and checked IPs. For this feature, It was necessary to handle 10th argument in `fncCheckSubnet` function and remove logs about failure or timeout of IPs.