### PR TITLE
removing "--ll" parameter from parallel

### DIFF
--- a/scripts/cfFindIP.sh
+++ b/scripts/cfFindIP.sh
@@ -235,7 +235,7 @@ do
 			killall v2ray > /dev/null 2>&1
 			ipList=$(nmap -sL -n "$subNet" | awk '/Nmap scan report/{print $NF}')
       tput cuu1; tput ed # rewrites Parallel's bar
-      parallel --ll --bar -j "$threads" fncCheckSubnet ::: "$ipList" ::: "$progressBar" ::: "$resultFile" ::: "$scriptDir" ::: "$configId" ::: "$configHost" ::: "$configPort" ::: "$configPath" ::: "$configServerName" ::: "$osVersion"
+      parallel --bar -j "$threads" fncCheckSubnet ::: "$ipList" ::: "$progressBar" ::: "$resultFile" ::: "$scriptDir" ::: "$configId" ::: "$configHost" ::: "$configPort" ::: "$configPath" ::: "$configServerName" ::: "$osVersion"
 			killall v2ray > /dev/null 2>&1
 		fi
     passedIpsCount=$(( passedIpsCount+1 ))


### PR DESCRIPTION
there is no "--ll" parameter in the parallel package, which causes the script to stop working