### PR TITLE
Use curl -f instead of curl -I & minify

### DIFF
--- a/bash/cfScanner.sh
+++ b/bash/cfScanner.sh
@@ -337,15 +337,15 @@ function fncMainCFFindSubnet {
 	
 	cloudFlareASNList=( AS13335 AS209242 )
 	
-	  printf "Updating config.real...\n"
+	  echo "Updating config.real...\n"
 	  if curl -sSfL http://bot.sudoer.net/config.real -o "$scriptDir"/config.real; then
-	    printf "config.real updated with http://bot.sudoer.net/config.real\n\n"
+	    echo "config.real updated with http://bot.sudoer.net/config.real\n\n"
 	    config="$scriptDir/config.real"
 		echo "$config"
 	    fncValidateConfig "$config"
 	  else
-	    printf "\nurl http://bot.sudoer.net/config.real is not reachable\n"
-	    printf "Make sure that you have the updated config.real\n\n"
+	    echo "\nurl http://bot.sudoer.net/config.real is not reachable\n"
+	    echo "Make sure that you have the updated config.real\n\n"
 	  fi
 
 	parallelVersion=$(parallel --version | head -n1 | grep -Ewo '[0-9]{8}')

--- a/bash/cfScanner.sh
+++ b/bash/cfScanner.sh
@@ -336,23 +336,17 @@ function fncMainCFFindSubnet {
 	fi
 	
 	cloudFlareASNList=( AS13335 AS209242 )
-
-	echo "updating config.real"
-	configRealUrlResult=$(curl -I -L -s http://bot.sudoer.net/config.real | grep "^HTTP" | grep 200 | awk '{ print $2 }')
-	if [[ "$configRealUrlResult" == "200" ]]
-	then
-		curl -s http://bot.sudoer.net/config.real -o "$scriptDir"/config.real
-		echo "config.real updated with http://bot.sudoer.net/config.real"
-		echo ""
-		config="$scriptDir/config.real"
+	
+	  printf "Updating config.real...\n"
+	  if curl -sSfL http://bot.sudoer.net/config.real -o "$scriptDir"/config.real; then
+	    printf "config.real updated with http://bot.sudoer.net/config.real\n\n"
+	    config="$scriptDir/config.real"
 		echo "$config"
-		fncValidateConfig "$config"
-	else
-		echo ""
-		echo "url http://bot.sudoer.net/config.real is not reachable"
-		echo "make sure that you have the updated config.real"
-		echo ""
-	fi
+	    fncValidateConfig "$config"
+	  else
+	    printf "\nurl http://bot.sudoer.net/config.real is not reachable\n"
+	    printf "Make sure that you have the updated config.real\n\n"
+	  fi
 
 	parallelVersion=$(parallel --version | head -n1 | grep -Ewo '[0-9]{8}')
 


### PR DESCRIPTION
Use curl -f instead of curl -I

>     (HTTP) Fail fast with no output at all on server errors. This is useful to enable scripts and users to better deal with failed attempts. In normal cases when an HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This flag will prevent curl from outputting that and return error 22.
>     This method is not fail-safe and there are occasions where non-successful response codes will slip through, especially when authentication is involved (response codes 401 and 407).