### PR TITLE
Py read default config

### DIFF
--- a/bash/ClientConfig.json
+++ b/bash/ClientConfig.json
@@ -1,8 +1,8 @@
 {
 	"id": "201b62c5-0f84-5e61-a220-4911c0c221b4",
-	"host": "scherehtzhel01.eersch.net",
+	"host": "scherebest.opensource.ga", 
 	"port": "443",
 	"path": "api01",
-	"serverName": "9144a6da-1323-4cea-8513-9ec0b707110a.eersch.net",
+	"serverName": "815a2e4b-f639-56f5-b498-2c149402ee80.opensource.ga",
 	"subnetsList": "https://raw.githubusercontent.com/MortezaBashsiz/CFScanner/main/config/cf.local.iplist"
 }

--- a/python/README.md
+++ b/python/README.md
@@ -119,7 +119,7 @@ To see the help message, use the `--help` or `-h` option.
 * `--tries`, `-n`: Number of times to try each IP. An IP is marked as OK if all tries are successful. Default value is 1.
 * `--subnets`, `-s`: The path to the custom subnets file. Each line should be either a single ip (v4 or v6) or a
   subnet in cidr notation (v4 or v6). If not provided, the program will
-  read the list of cidrs from [https://github.com/MortezaBashsiz/CFScanner/blob/main/bash/cf.local.iplist](https://github.com/MortezaBashsiz/CFScanner/blob/main/bash/cf.local.iplist).
+  read the list of cidrs from [https://github.com/MortezaBashsiz/CFScanner/blob/main/config/cf.local.iplist](https://github.com/MortezaBashsiz/CFScanner/blob/main/config/cf.local.iplist).
   
 #### Random Scan Options
 * `--sample`, `-r`: Size of the random sample to take from each subnet. The sample size can either
@@ -131,7 +131,7 @@ To see the help message, use the `--help` or `-h` option.
 
 #### Xray Config Options
 
-* `--config`, `-c`: The path to the config file. For config file example, see [sudoer default config](https://github.com/MortezaBashsiz/CFScanner/blob/main/bash/ClientConfig.json). If not provided, the program will read the [default sudoer config](https://github.com/MortezaBashsiz/CFScanner/blob/main/bash/ClientConfig.json) file.
+* `--config`, `-c`: The path to the config file. For config file example, see [sudoer default config](https://github.com/MortezaBashsiz/CFScanner/blob/main/config/ClientConfig.json). If not provided, the program will read the [default sudoer config](https://github.com/MortezaBashsiz/CFScanner/blob/main/config/ClientConfig.json) file.
 * `--template`: Path to the proxy (v2ray/xray) client file template. By default vmess_ws_tls is used.
 * `--binpath`, `-b`: Path to the v2ray/xray binary file. If not provided, will use the latest compatible version of xray.
 * `--novpn`: If passed, xray/v2ray service will not be started and the program will not use vpn.

--- a/python/cfscanner/args/parser.py
+++ b/python/cfscanner/args/parser.py
@@ -59,7 +59,7 @@ def parse_args():
         "--subnets", "-s",
         help="The path to the custom subnets file. Each line should be either a single ip (v4 or v6)"
         " or a subnet in cidr notation (v4 or v6). If not provided, the program will read the list of cidrs"
-        " from https://github.com/MortezaBashsiz/CFScanner/blob/main/bash/cf.local.iplist",
+        " from https://github.com/MortezaBashsiz/CFScanner/blob/main/config/cf.local.iplist",
         type=str,
         metavar="",
         dest="subnets",
@@ -99,7 +99,7 @@ def parse_args():
     config_or_template.add_argument(
         "--config", "-c",
         help="The path to the config file. For config file example,"
-        " see sudoer default config: https://github.com/MortezaBashsiz/CFScanner/blob/main/bash/ClientConfig.json"
+        " see sudoer default config: https://github.com/MortezaBashsiz/CFScanner/blob/main/cofig/ClientConfig.json"
         " If not provided, the program will read the default sudoer config file",
         metavar="",
         dest="config_path",

--- a/python/cfscanner/args/testconfig.py
+++ b/python/cfscanner/args/testconfig.py
@@ -27,7 +27,7 @@ class TestConfig:
             if args.config_path is None:
                 os.makedirs(os.path.join(SCRIPTDIR, ".tmp"), exist_ok=True)
                 download_file(
-                    url="https://raw.githubusercontent.com/MortezaBashsiz/CFScanner/main/bash/ClientConfig.json",
+                    url="https://raw.githubusercontent.com/MortezaBashsiz/CFScanner/main/config/ClientConfig.json",
                     save_path=os.path.join(SCRIPTDIR, ".tmp", "sudoer_config.json")
                 )
                 args.config_path = os.path.join(


### PR DESCRIPTION
- Read the default config from /config/ instead of /bash/
- Removed everything depending on bash directory and changed to config directory