### PR TITLE
Migrate to Generators instead of lists

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -238,6 +238,13 @@ Contributors names and contact info
   * changed fronting domain
 * 1.3.19
   * fixed a bug in xray config saving in windows. ":" is not allowed in windows file names
+* 1.4.0
+  * Improved memory usage
+    * The program now uses a generator to read ips from file/url
+    * The program uses [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) to select ips from the list
+    * Sampling till time out after ``sample-timeout`` seconds. In this case there is no guarantee that the probability of selecting the different ips are equal
+  * The main progress bar is now based on the number of subnets (not the total ips)
+  * The program does not remove the duplicate subnets anymore due to the new logic and in favor of memory usage
 
 [python]: https://img.shields.io/badge/-Python-3776AB?logo=python&logoColor=white
 [version]: https://img.shields.io/badge/Version-1.3.19-blue

--- a/python/README.md
+++ b/python/README.md
@@ -242,7 +242,8 @@ Contributors names and contact info
   * Improved memory usage
     * The program now uses a generator to read ips from file/url
     * The program uses [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) to select ips from the list
-    * Sampling till time out after ``sample-timeout`` seconds. In this case there is no guarantee that the probability of selecting the different ips are equal
+    * Sampling till time out after ``sample-timeout`` seconds (input argument, default 1). In this case there is no guarantee
+    that the probability of selecting the different ips are equal
   * The main progress bar is now based on the number of subnets (not the total ips)
   * The program does not remove the duplicate subnets anymore due to the new logic and in favor of memory usage
 

--- a/python/cfscanner/args/parser.py
+++ b/python/cfscanner/args/parser.py
@@ -90,6 +90,15 @@ def parse_args():
         required=False,
         default=False        
     )
+    randomscan_grp.add_argument(
+        "--sampling-timeout",
+        help="Maximum time (in seconds) to wait for a random sample to be taken from a subnet, default is 1",
+        type=float,
+        metavar="",
+        dest="sampling_timeout",
+        default=1
+        required=False
+    )
     ############################################################
     # Xray config options
     config_options = parser.add_argument_group(_title("Xray config options"))

--- a/python/cfscanner/args/parser.py
+++ b/python/cfscanner/args/parser.py
@@ -96,7 +96,7 @@ def parse_args():
         type=float,
         metavar="",
         dest="sampling_timeout",
-        default=1
+        default=1,
         required=False
     )
     ############################################################

--- a/python/cfscanner/args/testconfig.py
+++ b/python/cfscanner/args/testconfig.py
@@ -77,6 +77,7 @@ class TestConfig:
         test_config.no_fronting = args.no_fronting
 
         test_config.sample_size = args.sample_size
+        test_config.sampling_timeout = args.sampling_timeout
 
         system_info = detect_system()
         if test_config.novpn:

--- a/python/cfscanner/main.py
+++ b/python/cfscanner/main.py
@@ -177,7 +177,6 @@ ____ ____ ____ ____ ____ _  _ _  _ ____ ____
                 logger.exception(e)
                 exit(1)
 
-    test_config.sampling_timeout = 2
     def ip_generator():
         for cidr in cidr_generator:
             for ip in cidr_to_ip_gen(

--- a/python/cfscanner/subnets/__init__.py
+++ b/python/cfscanner/subnets/__init__.py
@@ -1,1 +1,1 @@
-from .cidr import read_cidrs, read_cidrs_from_file, read_cidrs_from_url, get_num_ips_in_cidr, cidr_to_ip_list
+from .cidr import read_cidrs, read_cidrs_from_file, read_cidrs_from_url, get_num_ips_in_cidr, cidr_to_ip_gen

--- a/python/cfscanner/subnets/cidr.py
+++ b/python/cfscanner/subnets/cidr.py
@@ -20,7 +20,8 @@ console = Console()
 
 def cidr_to_ip_gen(
     cidr: str,
-    sample_size: Union[int, float, None] = None
+    sample_size: Union[int, float, None] = None,
+    sampling_timeout: float = None
 ) -> list:
     """converts a subnet to a list of ips
 
@@ -28,6 +29,8 @@ def cidr_to_ip_gen(
         cidr (str): the cidr in the form of "ip/subnet"
         sample_size (Union[int, float, None], optional): The number of ips to sample from the subnet or
         the ratio of ips to sample from the subnet. If None, all ips will be returned Defaults to None.
+        sampling_timeout (float, optional): The timeout for the sampling process. Defaults to None. If exceeded, 
+        the sampling process will be terminated and the current sampled ips will be returned.
 
     Returns:
         list: a list of ips associated with the subnet
@@ -38,9 +41,17 @@ def cidr_to_ip_gen(
     if sample_size is None or sample_size >= n_ips:
         return ip_generator
     elif 1 <= sample_size < n_ips:
-        return reservoir_sampling(ip_generator, round(sample_size))
+        return reservoir_sampling(
+            ip_generator, 
+            round(sample_size),
+            sampling_timeout=sampling_timeout
+        )
     elif 0 < sample_size < 1:
-        return reservoir_sampling(ip_generator, math.ceil(n_ips * sample_size))
+        return reservoir_sampling(
+            ip_generator, 
+            math.ceil(n_ips * sample_size),
+            sampling_timeout=sampling_timeout
+        )
     else:
         raise ValueError(f"Invalid sample size: {sample_size}")
 

--- a/python/cfscanner/utils/os.py
+++ b/python/cfscanner/utils/os.py
@@ -73,3 +73,19 @@ def create_dir(dir_path):
     """
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
+        
+        
+def get_n_lines(path: str) -> int:
+    """returns the number of lines in a file
+
+    Args:
+        path (str): path to the file
+
+    Returns:
+        int: number of lines in the file
+    """    
+    with open(path, "rb") as infile:
+        for n_lines, _ in enumerate(infile):
+            pass        
+    return n_lines + 1
+    

--- a/python/cfscanner/utils/random.py
+++ b/python/cfscanner/utils/random.py
@@ -1,11 +1,13 @@
 import math
 import random
+import time
 from typing import Generator
 
 
 def reservoir_sampling(
     stream: Generator,
     sample_size: int,
+    sampling_timeout: float = None
 ) -> list:
     """Reservoir sampling algorithm.
     This algorithm is used to sample from a stream of data without knowing the size of the stream.
@@ -17,10 +19,13 @@ def reservoir_sampling(
     Args:
         stream (generator): the stream of data
         sample_size (int): the size of the sample to be drawn
+        sampling_timeout (float, optional): The timeout for the sampling process. Defaults to None. If exceeded, 
+        the sampling process will be terminated and the current sampled ips will be returned.
 
     Returns:
         list: the sample of size `sample_size` drawn from the stream
     """
+    start_time = time.time()
     sample = [next(stream) for _ in range(sample_size)]
     i = sample_size - 1
     w = math.exp(math.log(random.random()) / sample_size)
@@ -34,6 +39,8 @@ def reservoir_sampling(
             i += 1
             sample[random.randint(0, sample_size-1)] = next_elm
             w = w * math.exp(math.log(random.random())/sample_size)
+            if sampling_timeout is not None and time.time() - start_time > sampling_timeout:
+                break
         except StopIteration:
             break
     return sample

--- a/python/cfscanner/utils/random.py
+++ b/python/cfscanner/utils/random.py
@@ -1,0 +1,39 @@
+import math
+import random
+from typing import Generator
+
+
+def reservoir_sampling(
+    stream: Generator,
+    sample_size: int,
+) -> list:
+    """Reservoir sampling algorithm.
+    This algorithm is used to sample from a stream of data without knowing the size of the stream.
+    The algorithm is described in the following paper[1] and on wikipedia[2] (Algorithm L)
+    [1] Vitter, Jeffrey S. "Random sampling with a reservoir." ACM Transactions on Mathematical Software (TOMS) 11.1 (1985): 37-57.
+    [2] https://en.wikipedia.org/wiki/Reservoir_sampling
+
+
+    Args:
+        stream (generator): the stream of data
+        sample_size (int): the size of the sample to be drawn
+
+    Returns:
+        list: the sample of size `sample_size` drawn from the stream
+    """
+    sample = [next(stream) for _ in range(sample_size)]
+    i = sample_size - 1
+    w = math.exp(math.log(random.random()) / sample_size)
+    while True:
+        try:
+            jump = math.floor(math.log(random.random())/math.log(1 - w))
+            for _ in range(jump):
+                next(stream)  # discard elements
+                i += 1
+            next_elm = next(stream)
+            i += 1
+            sample[random.randint(0, sample_size-1)] = next_elm
+            w = w * math.exp(math.log(random.random())/sample_size)
+        except StopIteration:
+            break
+    return sample

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cfscanner"
-version = "1.3.19"
+version = "1.4.0a1"
 authors = [
   { name="tempookian", email="tempookian@gmail.com" },
   { name="Morteza Bashsiz", email="morteza.bashsiz@gmail.com"}


### PR DESCRIPTION
  * Improved memory usage
    * The program now uses a generator to read ips from file/url
    * The program uses [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) to select ips from the list
    * Sampling till time out after ``sample-timeout`` seconds (input argument, default 1). In this case there is no guarantee
    that the probability of selecting the different ips are equal
  * The main progress bar is now based on the number of subnets (not the total ips)
  * The program does not remove the duplicate subnets anymore due to the new logic and in favor of memory usage