### PR TITLE
Fix reading speed time from cf download and upload request

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -286,3 +286,5 @@ Contributors names and contact info
   - Add fronting-domain option
   - Default to fronting without fronting domain
   - Default xray core version changed to v1.8.10
+- 1.5.1
+  - Fixed a bug in reading the speed time from cloudflare response on download and upload requests

--- a/python/src/cfscanner/speedtest/download.py
+++ b/python/src/cfscanner/speedtest/download.py
@@ -26,7 +26,7 @@ def download_speed_test(
         proxies=proxies,
     )
     total_time = time.perf_counter() - start_time
-    cf_time = float(r.headers.get("Server-Timing").split("=")[1]) / 1000
+    cf_time = float(r.headers.get("Server-Timing").split(',')[0].split(';')[1].split('=')[1]) / 1000
     latency = r.elapsed.total_seconds() - cf_time
     download_time = total_time - latency
 

--- a/python/src/cfscanner/speedtest/upload.py
+++ b/python/src/cfscanner/speedtest/upload.py
@@ -29,7 +29,7 @@ def upload_speed_test(
         proxies=proxies,
     )
     total_time = time.perf_counter() - start_time
-    cf_time = float(r.headers.get("Server-Timing").split("=")[1]) / 1000
+    cf_time = float(r.headers.get("Server-Timing").split(',')[0].split(';')[1].split('=')[1]) / 1000
     latency = total_time - cf_time
 
     mb = n_bytes * 8 / (10**6)


### PR DESCRIPTION
The format of the ‍`Server-Timing` parameter has changed in response of requests to https://speed.cloudflare.com/__down and https://speed.cloudflare.com/__up. The new format is:

`'cfRequestDuration;dur=197.000027, cfL4;desc="?proto=TCP&rtt=112161&sent=13&recv=24&lost=0&retrans=0&sent_bytes=4767&recv_bytes=20846&delivery_rate=54007&cwnd=253&unsent_bytes=0&cid=c71ffe30d4797a23&ts=310"'`

Therefore, we can use the following new code to extract the `dur` value:
`r.headers.get("Server-Timing").split(',')[0].split(';')[1].split('=')[1]`