### PR TITLE
refactor(python): modernize scanner runtime and tooling (1.6.0a2)

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -10,3 +10,4 @@ log/
 result/
 venv/
 .python-version
+uv.lock

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -11,3 +11,4 @@ result/
 venv/
 .python-version
 xray-*
+test.json

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -10,4 +10,4 @@ log/
 result/
 venv/
 .python-version
-uv.lock
+xray-*

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,3 +5,13 @@
 | 1.5.4 | 2025-08-07 | Feat | add fronting domain option | tempookian | 28e62e5
 |  |  | Fix | client config was not updated after remote update | goingfine | 3f5b7bb
 |  |  | Refactor | update version handling and dependency | Tempookian | d4a03b4
+
+# CFSCanner (python) - Change Log
+
+| Version | Date | Type  | Message | Author | Commit |
+|---------|------|-------|---------|--------|--------|
+| 1.6.0a0 | 2026-01-30 | Feat | add fronting domain option | tempookian | 28e62e5
+|  |  | Fix | fix some logging issues | Tempookian | 6e66000
+|  |  |  | improve debug logs | Tempookian | 298fa15
+|  |  |  | client config was not updated after remote update | goingfine | 3f5b7bb
+|  |  | Refactor | update version handling and dependency | Tempookian | 55857ec

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -15,3 +15,14 @@
 |  |  |  | improve debug logs | Tempookian | 298fa15
 |  |  |  | client config was not updated after remote update | goingfine | 3f5b7bb
 |  |  | Refactor | update version handling and dependency | Tempookian | 55857ec
+
+# CFSCanner (python) - Change Log
+
+| Version | Date | Type  | Message | Author | Commit |
+|---------|------|-------|---------|--------|--------|
+| 1.6.0a1 | 2026-01-30 | Fix | fix log error | Tempookian | 9560674
+| 1.6.0a0 | 2026-01-30 | Feat | add fronting domain option | tempookian | 28e62e5
+|  |  | Fix | fix some logging issues | Tempookian | 6e66000
+|  |  |  | improve debug logs | Tempookian | 298fa15
+|  |  |  | client config was not updated after remote update | goingfine | 3f5b7bb
+|  |  | Refactor | update version handling and dependency | Tempookian | 55857ec

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",
 ]
-version = "1.6.0a1"
+version = "1.6.0a2"
 
 [project.scripts]
 cfscanner = "cfscanner:main"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
 ]
-version = "1.6.0a0"
+version = "1.6.0a1"
 
 [project.scripts]
 cfscanner = "cfscanner:main"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
 ]
-version = "1.5.4"
+version = "1.6.0a0"
 
 [project.scripts]
 cfscanner = "cfscanner:main"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "cfscanner"
 authors = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",
 ]
-version = "1.6.0a2"
+version = "1.6.1"
 
 [project.scripts]
 cfscanner = "cfscanner:main"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
 ]
 description = "Cloudflare's edge IPs scanner to locate ones that are viable for use with v2ray/xray"
 readme = "README.md"
+license = "GPL-3.0-or-later"
 dependencies = [
   "requests>=2.28.2",
   "pysocks>=1.7.1",
@@ -15,7 +16,6 @@ dependencies = [
 requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
 ]
 version = "1.6.0a1"
@@ -29,3 +29,22 @@ tag_format = "pyv$version"
 version_scheme = "pep440"
 version_provider = "pep621"
 update_changelog_on_bump = true
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+    "ruff>=0.16.2",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py38"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+# Long docstrings/help strings are common in this CLI tool; the formatter is
+# not run repo-wide as part of this pass, so don't flag line length.
+ignore = ["E501"]

--- a/python/src/cfscanner/args/parser.py
+++ b/python/src/cfscanner/args/parser.py
@@ -1,7 +1,7 @@
 import argparse
 
-from ..report.print import color_text
 from ..report.logging_setup import console
+from ..report.print import color_text
 
 
 def _title(text):

--- a/python/src/cfscanner/args/testconfig.py
+++ b/python/src/cfscanner/args/testconfig.py
@@ -3,9 +3,9 @@ import json
 import os
 
 from ..utils.exceptions import (
-    TemplateReadError,
-    BinaryNotFoundError,
     BinaryDownloadError,
+    BinaryNotFoundError,
+    TemplateReadError,
 )
 from ..utils.os import detect_system
 from ..utils.requests import download_file
@@ -35,7 +35,7 @@ class TestConfig:
                     save_path=os.path.join(SCRIPTDIR, ".tmp", "sudoer_config.json"),
                 )
                 args.config_path = os.path.join(SCRIPTDIR, ".tmp", "sudoer_config.json")
-            with open(args.config_path, "r") as infile:
+            with open(args.config_path) as infile:
                 file_content = json.load(infile)
                 test_config.user_id = file_content["id"]
                 test_config.ws_header_host = file_content["host"]
@@ -51,18 +51,18 @@ class TestConfig:
         else:
             test_config.custom_template = True  # user provided a custom template
             try:
-                with open(args.template_path, "r") as infile:
+                with open(args.template_path) as infile:
                     test_config.proxy_config_template = infile.read()
-            except FileNotFoundError:
-                raise TemplateReadError("template file not found")
-            except IsADirectoryError:
+            except FileNotFoundError as err:
+                raise TemplateReadError("template file not found") from err
+            except IsADirectoryError as err:
                 raise TemplateReadError(
                     "template file is a directory. please provide the path to the file"
-                )
-            except PermissionError:
-                raise TemplateReadError("permission denied while reading template file")
-            except Exception as e:
-                raise TemplateReadError(f"error while reading template file: {e}")
+                ) from err
+            except PermissionError as err:
+                raise TemplateReadError("permission denied while reading template file") from err
+            except Exception as err:
+                raise TemplateReadError(f"error while reading template file: {err}") from err
 
         # speed related config
         test_config.startprocess_timeout = args.startprocess_timeout
@@ -98,7 +98,7 @@ class TestConfig:
                 test_config.binpath = download_binary(
                     system_info=system_info, bin_dir=SCRIPTDIR
                 )
-            except Exception as e:
-                raise BinaryDownloadError(str(e))
+            except Exception as err:
+                raise BinaryDownloadError(str(err)) from err
 
         return test_config

--- a/python/src/cfscanner/main.py
+++ b/python/src/cfscanner/main.py
@@ -5,30 +5,28 @@ import multiprocessing
 import signal
 import statistics
 from functools import partial
-
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 from .args.parser import parse_args
 from .args.testconfig import TestConfig
+from .report.logging_setup import (
+    CONFIGDIR,
+    INTERIM_RESULTS_PATH,
+    RESULTDIR,
+    START_DT_STR,
+    console,
+)
 from .report.print import TitledProgress
 from .speedtest.conduct import test_ip
 from .speedtest.tools import is_blocked, mean_jitter
 from .subnets.cidr import cidr_to_ip_gen, get_num_ips_in_cidr, read_cidrs
 from .utils.exceptions import (
     BinaryNotFoundError,
-    TemplateReadError,
     StartProxyServiceError,
     SubnetsReadError,
+    TemplateReadError,
 )
 from .utils.os import create_dir
-from .report.logging_setup import (
-    console,
-    CONFIGDIR,
-    RESULTDIR,
-    START_DT_STR,
-    INTERIM_RESULTS_PATH,
-)
-
 
 logger = logging.getLogger("cfscanner")
 
@@ -45,7 +43,7 @@ def _init_pool():
 
 
 def main():
-    logo = """                                                                                                                                        
+    logo = r"""
 ____ ____ ____ ____ ____ _  _ _  _ ____ ____ 
 |    |___ [__  |    |__| |\ | |\ | |___ |__/ 
 |___ |    ___] |___ |  | | \| | \| |___ |  \ 

--- a/python/src/cfscanner/report/logging_setup.py
+++ b/python/src/cfscanner/report/logging_setup.py
@@ -1,9 +1,10 @@
-from rich.console import Console
 import logging
-import fancylogging
 import os
 import pathlib
 from datetime import datetime
+
+import fancylogging
+from rich.console import Console
 
 SCRIPTDIR = os.getcwd()
 CONFIGDIR = f"{SCRIPTDIR}/.xray-configs"

--- a/python/src/cfscanner/report/print.py
+++ b/python/src/cfscanner/report/print.py
@@ -13,149 +13,147 @@ log = logging.getLogger(__name__)
 
 
 class TitledProgress(Progress):
-  def __init__(
-    self,
-    *columns: Union[str, ProgressColumn],
-    title=None,
-    console: Optional[Console] = None,
-    auto_refresh: bool = True,
-    refresh_per_second: float = 10,
-    speed_estimate_period: float = 30,
-    transient: bool = False,
-    redirect_stdout: bool = True,
-    redirect_stderr: bool = True,
-    get_time: Optional[GetTimeCallable] = None,
-    disable: bool = False,
-    expand: bool = False,
-    scanned_ips: int = 0,
-    ok_ips: int = 0,
-  ) -> None:
-    self.title = title
-    self.scanned_ips = scanned_ips
-    self.ok_ips = ok_ips
-    super().__init__(
-      *columns,
-      console=console,
-      auto_refresh=auto_refresh,
-      refresh_per_second=refresh_per_second,
-      speed_estimate_period=speed_estimate_period,
-      transient=transient,
-      redirect_stdout=redirect_stdout,
-      redirect_stderr=redirect_stderr,
-      get_time=get_time,
-      disable=disable,
-      expand=expand,
-    )
-
-  def make_tasks_table(self, tasks: Iterable[Task]) -> Table:
-    table_columns = (
-      (
-        Column(no_wrap=True)
-        if isinstance(_column, str)
-        else _column.get_table_column().copy()
-      )
-      for _column in self.columns
-    )
-    table = Table.grid(*table_columns, padding=(0, 1), expand=self.expand)
-
-    if self.title is not None:
-      table.add_row(self.title)
-    if self.scanned_ips is not None and self.ok_ips is not None:
-      table.add_row(
-        f"scanned ips:{str(self.scanned_ips).ljust(8)}"
-        f"ok ips: {self.ok_ips} "
-        f"({self.ok_ips / self.scanned_ips * 100:.2f}%)"
-        if self.scanned_ips > 0
-        else ""
-      )
-
-    for task in tasks:
-      if task.visible:
-        table.add_row(
-          *(
-            (column.format(task=task) if isinstance(column, str) else column(task))
-            for column in self.columns
-          )
+    def __init__(
+        self,
+        *columns: Union[str, ProgressColumn],
+        title=None,
+        console: Optional[Console] = None,
+        auto_refresh: bool = True,
+        refresh_per_second: float = 10,
+        speed_estimate_period: float = 30,
+        transient: bool = False,
+        redirect_stdout: bool = True,
+        redirect_stderr: bool = True,
+        get_time: Optional[GetTimeCallable] = None,
+        disable: bool = False,
+        expand: bool = False,
+        scanned_ips: int = 0,
+        ok_ips: int = 0,
+    ) -> None:
+        self.title = title
+        self.scanned_ips = scanned_ips
+        self.ok_ips = ok_ips
+        super().__init__(
+            *columns,
+            console=console,
+            auto_refresh=auto_refresh,
+            refresh_per_second=refresh_per_second,
+            speed_estimate_period=speed_estimate_period,
+            transient=transient,
+            redirect_stdout=redirect_stdout,
+            redirect_stderr=redirect_stderr,
+            get_time=get_time,
+            disable=disable,
+            expand=expand,
         )
-    return table
+
+    def make_tasks_table(self, tasks: Iterable[Task]) -> Table:
+        table_columns = (
+            (
+                Column(no_wrap=True)
+                if isinstance(_column, str)
+                else _column.get_table_column().copy()
+            )
+            for _column in self.columns
+        )
+        table = Table.grid(*table_columns, padding=(0, 1), expand=self.expand)
+
+        if self.title is not None:
+            table.add_row(self.title)
+        if self.scanned_ips is not None and self.ok_ips is not None:
+            table.add_row(
+                f"scanned ips:{str(self.scanned_ips).ljust(8)}"
+                f"ok ips: {self.ok_ips} "
+                f"({self.ok_ips / self.scanned_ips * 100:.2f}%)"
+                if self.scanned_ips > 0
+                else ""
+            )
+
+        for task in tasks:
+            if task.visible:
+                table.add_row(
+                    *(
+                        (column.format(task=task) if isinstance(column, str) else column(task))
+                        for column in self.columns
+                    )
+                )
+        return table
 
 
 def no_and_kill(ip: str, message: str, process: Popen):
-  """prints an error message together with the respective ip that causes the error message in a nice colored format
+    """prints an error message together with the respective ip that causes the error message in a nice colored format
 
-  Args:
-      ip (str): the ip that causes the error
-      message (str): the message related to the error
-      process (Popen): the process (xray) to be killed
-  """
-  log.debug("Result No", extra={"ip": ip, "err_message": message})
-  process.kill()
-  return f"[bold red1]NO[/bold red1] [orange3]{ip:15s}[/orange3] [yellow1]{message}[/yellow1]"
+    Args:
+        ip (str): the ip that causes the error
+        message (str): the message related to the error
+        process (Popen): the process (xray) to be killed
+    """
+    log.debug("Result No", extra={"ip": ip, "err_message": message})
+    process.kill()
+    return f"[bold red1]NO[/bold red1] [orange3]{ip:15s}[/orange3] [yellow1]{message}[/yellow1]"
 
 
-def ok_message(scan_result: dict) -> None:
-  """prints the result if test is ok
+def ok_message(scan_result: dict) -> str:
+    """prints the result if test is ok
 
-  Args:
-      scan_result (dict): the results of the scan
-  """
-  down_mean_jitter = mean_jitter(scan_result["download"]["latency"])
-  up_mean_jitter = mean_jitter(scan_result["upload"]["latency"])
-  mean_down_speed = mean(scan_result["download"]["speed"])
-  mean_up_speed = mean(scan_result["upload"]["speed"])
-  mean_down_latency = mean(scan_result["download"]["latency"])
-  mean_up_latency = mean(scan_result["upload"]["latency"])
-  return (
-    f"[bold green1]"
-    f"OK [/bold green1][cyan1]{scan_result['ip']:15s}[/cyan1][bright_blue] "
-    f"avg_down_speed: {mean_down_speed:7.4f}mbps "
-    f"avg_up_speed: {mean_up_speed:7.4f}mbps "
-    f"avg_down_latency: {mean_down_latency:7.2f}ms "
-    f"avg_up_latency: {mean_up_latency:7.2f}ms "
-    f"avg_down_jitter: {down_mean_jitter:7.2f}ms "
-    f"avg_up_jitter: {up_mean_jitter:4.2f}ms"
-    f"[/bright_blue]"
-  )
+    Args:
+        scan_result (dict): the results of the scan
+    """
+    down_mean_jitter = mean_jitter(scan_result["download"]["latency"])
+    up_mean_jitter = mean_jitter(scan_result["upload"]["latency"])
+    mean_down_speed = mean(scan_result["download"]["speed"])
+    mean_up_speed = mean(scan_result["upload"]["speed"])
+    mean_down_latency = mean(scan_result["download"]["latency"])
+    mean_up_latency = mean(scan_result["upload"]["latency"])
+    return (
+        f"[bold green1]"
+        f"OK [/bold green1][cyan1]{scan_result['ip']:15s}[/cyan1][bright_blue] "
+        f"avg_down_speed: {mean_down_speed:7.4f}mbps "
+        f"avg_up_speed: {mean_up_speed:7.4f}mbps "
+        f"avg_down_latency: {mean_down_latency:7.2f}ms "
+        f"avg_up_latency: {mean_up_latency:7.2f}ms "
+        f"avg_down_jitter: {down_mean_jitter:7.2f}ms "
+        f"avg_up_jitter: {up_mean_jitter:4.2f}ms"
+        f"[/bright_blue]"
+    )
 
 
 def color_text(text: str, rgb: tuple, bold: bool = False):
-  """prints a colored text in the terminal using ANSI escape codes based on the rgb values
+    """prints a colored text in the terminal using ANSI escape codes based on the rgb values
 
-  Args:
-      text (str): the text to be printed
-      rgb (tuple): the rgb values of the color
-  """
-  if bold:
-    return f"\033[1m\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
-  else:
-    return f"\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
+    Args:
+        text (str): the text to be printed
+        rgb (tuple): the rgb values of the color
+    """
+    if bold:
+        return f"\033[1m\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
+    else:
+        return f"\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
 
 
 def box_text(text: str):
-  """prints a box around the text
+    """prints a box around the text
 
-  Args:
-      text (str): the text to be printed in the box
+    Args:
+        text (str): the text to be printed in the box
 
-  Returns:
-      str: the text with the box around it
-  """
-  lines = text.splitlines()
-  max_width = max(len(line) for line in lines)
+    Returns:
+        str: the text with the box around it
+    """
+    lines = text.splitlines()
+    max_width = max(len(line) for line in lines)
 
-  # Define the ANSI escape codes for the header
-  HEADER_COLOR = "\033[38;2;64;224;208m"
-  BORDER_COLOR = "\033[38;2;100;100;100m"
-  BOX_WIDTH = max_width + 10
+    # Define the ANSI escape codes for the header
+    HEADER_COLOR = "\033[38;2;64;224;208m"
+    BORDER_COLOR = "\033[38;2;100;100;100m"
+    BOX_WIDTH = max_width + 10
 
-  res_text = ""
+    res_text = ""
 
-  # Print the header with a colored border
-  res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\n"
-  for line in lines:
-    res_text += (
-      f"{BORDER_COLOR}|{HEADER_COLOR}{line.center(BOX_WIDTH - 2)}{BORDER_COLOR}|\n"
-    )
-  res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\033[m"
+    # Print the header with a colored border
+    res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\n"
+    for line in lines:
+        res_text += f"{BORDER_COLOR}|{HEADER_COLOR}{line.center(BOX_WIDTH - 2)}{BORDER_COLOR}|\n"
+    res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\033[m"
 
-  return res_text
+    return res_text

--- a/python/src/cfscanner/report/print.py
+++ b/python/src/cfscanner/report/print.py
@@ -88,7 +88,7 @@ def no_and_kill(ip: str, message: str, process: Popen):
       message (str): the message related to the error
       process (Popen): the process (xray) to be killed
   """
-  log.debug("Result No", extra={"ip": ip, "message": message})
+  log.debug("Result No", extra={"ip": ip, "err_message": message})
   process.kill()
   return f"[bold red1]NO[/bold red1] [orange3]{ip:15s}[/orange3] [yellow1]{message}[/yellow1]"
 

--- a/python/src/cfscanner/report/print.py
+++ b/python/src/cfscanner/report/print.py
@@ -1,3 +1,4 @@
+import logging
 from statistics import mean
 from subprocess import Popen
 from typing import Iterable, Optional, Union
@@ -8,152 +9,153 @@ from rich.table import Column, Table
 
 from ..speedtest.tools import mean_jitter
 
+log = logging.getLogger(__name__)
+
 
 class TitledProgress(Progress):
-    def __init__(
-        self,
-        *columns: Union[str, ProgressColumn],
-        title=None,
-        console: Optional[Console] = None,
-        auto_refresh: bool = True,
-        refresh_per_second: float = 10,
-        speed_estimate_period: float = 30,
-        transient: bool = False,
-        redirect_stdout: bool = True,
-        redirect_stderr: bool = True,
-        get_time: Optional[GetTimeCallable] = None,
-        disable: bool = False,
-        expand: bool = False,
-        scanned_ips: int = 0,
-        ok_ips: int = 0,
-    ) -> None:
-        self.title = title
-        self.scanned_ips = scanned_ips
-        self.ok_ips = ok_ips
-        super().__init__(
-            *columns,
-            console=console,
-            auto_refresh=auto_refresh,
-            refresh_per_second=refresh_per_second,
-            speed_estimate_period=speed_estimate_period,
-            transient=transient,
-            redirect_stdout=redirect_stdout,
-            redirect_stderr=redirect_stderr,
-            get_time=get_time,
-            disable=disable,
-            expand=expand,
+  def __init__(
+    self,
+    *columns: Union[str, ProgressColumn],
+    title=None,
+    console: Optional[Console] = None,
+    auto_refresh: bool = True,
+    refresh_per_second: float = 10,
+    speed_estimate_period: float = 30,
+    transient: bool = False,
+    redirect_stdout: bool = True,
+    redirect_stderr: bool = True,
+    get_time: Optional[GetTimeCallable] = None,
+    disable: bool = False,
+    expand: bool = False,
+    scanned_ips: int = 0,
+    ok_ips: int = 0,
+  ) -> None:
+    self.title = title
+    self.scanned_ips = scanned_ips
+    self.ok_ips = ok_ips
+    super().__init__(
+      *columns,
+      console=console,
+      auto_refresh=auto_refresh,
+      refresh_per_second=refresh_per_second,
+      speed_estimate_period=speed_estimate_period,
+      transient=transient,
+      redirect_stdout=redirect_stdout,
+      redirect_stderr=redirect_stderr,
+      get_time=get_time,
+      disable=disable,
+      expand=expand,
+    )
+
+  def make_tasks_table(self, tasks: Iterable[Task]) -> Table:
+    table_columns = (
+      (
+        Column(no_wrap=True)
+        if isinstance(_column, str)
+        else _column.get_table_column().copy()
+      )
+      for _column in self.columns
+    )
+    table = Table.grid(*table_columns, padding=(0, 1), expand=self.expand)
+
+    if self.title is not None:
+      table.add_row(self.title)
+    if self.scanned_ips is not None and self.ok_ips is not None:
+      table.add_row(
+        f"scanned ips:{str(self.scanned_ips).ljust(8)}"
+        f"ok ips: {self.ok_ips} "
+        f"({self.ok_ips / self.scanned_ips * 100:.2f}%)"
+        if self.scanned_ips > 0
+        else ""
+      )
+
+    for task in tasks:
+      if task.visible:
+        table.add_row(
+          *(
+            (column.format(task=task) if isinstance(column, str) else column(task))
+            for column in self.columns
+          )
         )
-
-    def make_tasks_table(self, tasks: Iterable[Task]) -> Table:
-        table_columns = (
-            (
-                Column(no_wrap=True)
-                if isinstance(_column, str)
-                else _column.get_table_column().copy()
-            )
-            for _column in self.columns
-        )
-        table = Table.grid(*table_columns, padding=(0, 1), expand=self.expand)
-
-        if self.title is not None:
-            table.add_row(self.title)
-        if self.scanned_ips is not None and self.ok_ips is not None:
-            table.add_row(
-                f"scanned ips:{str(self.scanned_ips).ljust(8)}"
-                f"ok ips: {self.ok_ips} "
-                f"({self.ok_ips / self.scanned_ips * 100:.2f}%)"
-                if self.scanned_ips > 0
-                else ""
-            )
-
-        for task in tasks:
-            if task.visible:
-                table.add_row(
-                    *(
-                        (
-                            column.format(task=task)
-                            if isinstance(column, str)
-                            else column(task)
-                        )
-                        for column in self.columns
-                    )
-                )
-        return table
+    return table
 
 
 def no_and_kill(ip: str, message: str, process: Popen):
-    """prints an error message together with the respective ip that causes the error message in a nice colored format
+  """prints an error message together with the respective ip that causes the error message in a nice colored format
 
-    Args:
-        ip (str): the ip that causes the error
-        message (str): the message related to the error
-        process (Popen): the process (xray) to be killed
-    """
-    process.kill()
-    return f"[bold red1]NO[/bold red1] [orange3]{ip:15s}[/orange3] [yellow1]{message}[/yellow1]"
+  Args:
+      ip (str): the ip that causes the error
+      message (str): the message related to the error
+      process (Popen): the process (xray) to be killed
+  """
+  log.debug("Result No", extra={"ip": ip, "message": message})
+  process.kill()
+  return f"[bold red1]NO[/bold red1] [orange3]{ip:15s}[/orange3] [yellow1]{message}[/yellow1]"
 
 
 def ok_message(scan_result: dict) -> None:
-    """prints the result if test is ok
+  """prints the result if test is ok
 
-    Args:
-        scan_result (dict): the results of the scan
-    """
-    down_mean_jitter = mean_jitter(scan_result["download"]["latency"])
-    up_mean_jitter = mean_jitter(scan_result["upload"]["latency"])
-    mean_down_speed = mean(scan_result["download"]["speed"])
-    mean_up_speed = mean(scan_result["upload"]["speed"])
-    mean_down_latency = mean(scan_result["download"]["latency"])
-    mean_up_latency = mean(scan_result["upload"]["latency"])
-    return (
-        f"[bold green1]"
-        f"OK [/bold green1][cyan1]{scan_result['ip']:15s}[/cyan1][bright_blue] "
-        f"avg_down_speed: {mean_down_speed:7.4f}mbps "
-        f"avg_up_speed: {mean_up_speed:7.4f}mbps "
-        f"avg_down_latency: {mean_down_latency:7.2f}ms "
-        f"avg_up_latency: {mean_up_latency:7.2f}ms "
-        f"avg_down_jitter: {down_mean_jitter:7.2f}ms "
-        f"avg_up_jitter: {up_mean_jitter:4.2f}ms"
-        f"[/bright_blue]"
-    )
+  Args:
+      scan_result (dict): the results of the scan
+  """
+  down_mean_jitter = mean_jitter(scan_result["download"]["latency"])
+  up_mean_jitter = mean_jitter(scan_result["upload"]["latency"])
+  mean_down_speed = mean(scan_result["download"]["speed"])
+  mean_up_speed = mean(scan_result["upload"]["speed"])
+  mean_down_latency = mean(scan_result["download"]["latency"])
+  mean_up_latency = mean(scan_result["upload"]["latency"])
+  return (
+    f"[bold green1]"
+    f"OK [/bold green1][cyan1]{scan_result['ip']:15s}[/cyan1][bright_blue] "
+    f"avg_down_speed: {mean_down_speed:7.4f}mbps "
+    f"avg_up_speed: {mean_up_speed:7.4f}mbps "
+    f"avg_down_latency: {mean_down_latency:7.2f}ms "
+    f"avg_up_latency: {mean_up_latency:7.2f}ms "
+    f"avg_down_jitter: {down_mean_jitter:7.2f}ms "
+    f"avg_up_jitter: {up_mean_jitter:4.2f}ms"
+    f"[/bright_blue]"
+  )
 
 
 def color_text(text: str, rgb: tuple, bold: bool = False):
-    """prints a colored text in the terminal using ANSI escape codes based on the rgb values
+  """prints a colored text in the terminal using ANSI escape codes based on the rgb values
 
-    Args:
-        text (str): the text to be printed
-        rgb (tuple): the rgb values of the color
-    """
-    if bold:
-        return f"\033[1m\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
-    else:
-        return f"\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
+  Args:
+      text (str): the text to be printed
+      rgb (tuple): the rgb values of the color
+  """
+  if bold:
+    return f"\033[1m\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
+  else:
+    return f"\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m{text}\033[m"
 
 
 def box_text(text: str):
-    """prints a box around the text
+  """prints a box around the text
 
-    Args:
-        text (str): the text to be printed in the box
+  Args:
+      text (str): the text to be printed in the box
 
-    Returns:
-        str: the text with the box around it
-    """
-    lines = text.splitlines()
-    max_width = max(len(line) for line in lines)
+  Returns:
+      str: the text with the box around it
+  """
+  lines = text.splitlines()
+  max_width = max(len(line) for line in lines)
 
-    # Define the ANSI escape codes for the header
-    HEADER_COLOR = "\033[38;2;64;224;208m"
-    BORDER_COLOR = "\033[38;2;100;100;100m"
-    BOX_WIDTH = max_width + 10
+  # Define the ANSI escape codes for the header
+  HEADER_COLOR = "\033[38;2;64;224;208m"
+  BORDER_COLOR = "\033[38;2;100;100;100m"
+  BOX_WIDTH = max_width + 10
 
-    res_text = ""
+  res_text = ""
 
-    # Print the header with a colored border
-    res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\n"
-    for line in lines:
-        res_text += f"{BORDER_COLOR}|{HEADER_COLOR}{line.center(BOX_WIDTH - 2)}{BORDER_COLOR}|\n"
-    res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\033[m"
+  # Print the header with a colored border
+  res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\n"
+  for line in lines:
+    res_text += (
+      f"{BORDER_COLOR}|{HEADER_COLOR}{line.center(BOX_WIDTH - 2)}{BORDER_COLOR}|\n"
+    )
+  res_text += f"{BORDER_COLOR}{'+' + '-' * (BOX_WIDTH - 2) + '+'}\033[m"
 
-    return res_text
+  return res_text

--- a/python/src/cfscanner/speedtest/conduct.py
+++ b/python/src/cfscanner/speedtest/conduct.py
@@ -50,7 +50,7 @@ def test_ip(ip_cidr: tuple, test_config: TestConfig, config_dir: str):
   test_result = TestResult(ip=ip, cidr=cidr, n_tries=test_config.n_tries)
 
   if not test_config.no_fronting:
-    for try_idx in range(test_config.n_tries):
+    for _try_idx in range(test_config.n_tries):
       fronting_result_msg = fronting_test(ip, timeout=test_config.fronting_timeout)
       if "NO" in fronting_result_msg:
         test_result.message = fronting_result_msg
@@ -78,9 +78,9 @@ def test_ip(ip_cidr: tuple, test_config: TestConfig, config_dir: str):
         binary_path=test_config.binpath,
         timeout=test_config.startprocess_timeout,
       )
-    except Exception:
+    except Exception as err:
       test_result.is_ok = False
-      raise StartProxyServiceError(f"Could not start xray service - {ip}")
+      raise StartProxyServiceError(f"Could not start xray service - {ip}") from err
 
   else:
     process = _FakeProcess()

--- a/python/src/cfscanner/speedtest/conduct.py
+++ b/python/src/cfscanner/speedtest/conduct.py
@@ -105,7 +105,7 @@ def test_ip(ip_cidr: tuple, test_config: TestConfig, config_dir: str):
       )
       log.debug(
         "Timeout in dl test",
-        extra={"ip": ip, "cidr": cidr, "dl_speed": dl_speed, "dl_latency": dl_latency},
+        extra={"ip": ip, "cidr": cidr},
       )
       test_result.message = fail_msg
       test_result.is_ok = False

--- a/python/src/cfscanner/speedtest/conduct.py
+++ b/python/src/cfscanner/speedtest/conduct.py
@@ -16,230 +16,226 @@ log = logging.getLogger(__name__)
 
 
 class TestResult:
-  """class to store test results"""
+    """class to store test results"""
 
-  def __init__(self, ip, cidr, n_tries):
-    self.ip = ip
-    self.cidr = cidr
+    def __init__(self, ip, cidr, n_tries):
+        self.ip = ip
+        self.cidr = cidr
 
-    self.is_ok = False
-    self.n_tries = n_tries
-    self.message = ""
+        self.is_ok = False
+        self.n_tries = n_tries
+        self.message = ""
 
-    self.result = dict(
-      ip=ip,
-      success=False,
-      download=dict(speed=[-1] * self.n_tries, latency=[-1] * self.n_tries),
-      upload=dict(speed=[-1] * self.n_tries, latency=[-1] * self.n_tries),
-    )
+        self.result = dict(
+            ip=ip,
+            success=False,
+            download=dict(speed=[-1] * self.n_tries, latency=[-1] * self.n_tries),
+            upload=dict(speed=[-1] * self.n_tries, latency=[-1] * self.n_tries),
+        )
 
-  def __bool__(self):
-    return self.is_ok
+    def __bool__(self):
+        return self.is_ok
 
 
 class _FakeProcess:
-  def __init__(self):
-    pass
+    def __init__(self):
+        pass
 
-  def kill(self):
-    pass
+    def kill(self):
+        pass
 
 
 def test_ip(ip_cidr: tuple, test_config: TestConfig, config_dir: str):
-  ip, cidr = ip_cidr
-  test_result = TestResult(ip=ip, cidr=cidr, n_tries=test_config.n_tries)
+    ip, cidr = ip_cidr
+    test_result = TestResult(ip=ip, cidr=cidr, n_tries=test_config.n_tries)
 
-  if not test_config.no_fronting:
-    for _try_idx in range(test_config.n_tries):
-      fronting_result_msg = fronting_test(ip, timeout=test_config.fronting_timeout)
-      if "NO" in fronting_result_msg:
-        test_result.message = fronting_result_msg
-        test_result.is_ok = False
-        return test_result
+    if not test_config.no_fronting:
+        for _try_idx in range(test_config.n_tries):
+            fronting_result_msg = fronting_test(ip, timeout=test_config.fronting_timeout)
+            if "NO" in fronting_result_msg:
+                test_result.message = fronting_result_msg
+                test_result.is_ok = False
+                return test_result
 
-  if not test_config.novpn:
-    try:
-      proxy_config_path = create_proxy_config(
-        edge_ip=ip, test_config=test_config, config_dir=config_dir
-      )
-    except Exception:
-      test_result.message = no_and_kill(
-        ip=ip,
-        message="Could not save proxy (xray/v2ray) config to file",
-        process=_FakeProcess(),
-      )
-      test_result.is_ok = False
-      return test_result
+    if not test_config.novpn:
+        try:
+            proxy_config_path = create_proxy_config(
+                edge_ip=ip, test_config=test_config, config_dir=config_dir
+            )
+        except Exception:
+            test_result.message = no_and_kill(
+                ip=ip,
+                message="Could not save proxy (xray/v2ray) config to file",
+                process=_FakeProcess(),
+            )
+            test_result.is_ok = False
+            return test_result
 
-  if not test_config.novpn:
-    try:
-      process, proxies = start_proxy_service(
-        proxy_conf_path=proxy_config_path,
-        binary_path=test_config.binpath,
-        timeout=test_config.startprocess_timeout,
-      )
-    except Exception as err:
-      test_result.is_ok = False
-      raise StartProxyServiceError(f"Could not start xray service - {ip}") from err
+    if not test_config.novpn:
+        try:
+            process, proxies = start_proxy_service(
+                proxy_conf_path=proxy_config_path,
+                binary_path=test_config.binpath,
+                timeout=test_config.startprocess_timeout,
+            )
+        except Exception as err:
+            test_result.is_ok = False
+            raise StartProxyServiceError(f"Could not start xray service - {ip}") from err
 
-  else:
-    process = _FakeProcess()
-    proxies = None
-
-  @timeout_fun(test_config.max_dl_latency + test_config.max_dl_time)
-  def timeout_download_fun():
-    return download_speed_test(
-      n_bytes=n_bytes,
-      proxies=proxies,
-      timeout=test_config.max_dl_latency,
-    )
-
-  for try_idx in range(test_config.n_tries):
-    # check download speed
-    n_bytes = test_config.min_dl_speed * 1000 * test_config.max_dl_time
-    try:
-      dl_speed, dl_latency = timeout_download_fun()
-    except TimeoutError:
-      fail_msg = no_and_kill(
-        ip=ip, message="download timeout exceeded", process=process
-      )
-      log.debug(
-        "Timeout in dl test",
-        extra={"ip": ip, "cidr": cidr},
-      )
-      test_result.message = fail_msg
-      test_result.is_ok = False
-      return test_result
-    except (
-      requests.exceptions.ReadTimeout,
-      requests.exceptions.ConnectionError,
-      requests.ConnectTimeout,
-    ) as e:
-      log.debug(
-        "Requests error in dl test", extra={"ip": ip, "cidr": cidr, "error": str(e)}
-      )
-      fail_msg = no_and_kill(ip=ip, message="download error", process=process)
-      test_result.message = fail_msg
-      test_result.is_ok = False
-      return test_result
-    except Exception as e:
-      log.exception(e)
-      log.error(
-        f"Download unknown error: {e}",
-        extra={
-          "ip": ip,
-          "cidr": cidr,
-        },
-      )
-      fail_msg = no_and_kill(ip=ip, message="download unknown error", process=process)
-      test_result.message = fail_msg
-      test_result.is_ok = False
-      return test_result
-
-    if dl_latency <= test_config.max_dl_latency:
-      log.debug(
-        "dl_latency acceptable",
-        extra={
-          "ip": ip,
-          "cidr": cidr,
-          "dl_latency": dl_latency,
-          "max_acceptable": test_config.max_dl_latency,
-        },
-      )
-      dl_speed_kBps = dl_speed / 8 * 1000
-      if dl_speed_kBps >= test_config.min_dl_speed:
-        test_result.result["download"]["speed"][try_idx] = dl_speed
-        test_result.result["download"]["latency"][try_idx] = round(dl_latency * 1000)
-      else:
-        log.debug(
-          "download speed too low",
-          extra={"ip": ip, "cidr": cidr, "dl_speed_kBps": dl_speed_kBps},
-        )
-        message = (
-          f"download too slow {dl_speed_kBps:.2f} < {test_config.min_dl_speed:.2f} kBps"
-        )
-        fail_msg = no_and_kill(ip=ip, message=message, process=process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
     else:
-      message = (
-        f"high download latency {dl_latency:.4f} s > {test_config.max_dl_latency:.4f} s"
-      )
-      fail_msg = no_and_kill(ip=ip, message=message, process=process)
-      test_result.message = fail_msg
-      test_result.is_ok = False
-      return test_result
+        process = _FakeProcess()
+        proxies = None
 
-    # upload speed test
-    if test_config.do_upload_test:
-      n_bytes = test_config.min_ul_speed * 1000 * test_config.max_ul_time
-      try:
-        up_speed, up_latency = upload_speed_test(
-          n_bytes=n_bytes,
-          proxies=proxies,
-          timeout=test_config.max_ul_latency + test_config.max_ul_time,
+    @timeout_fun(test_config.max_dl_latency + test_config.max_dl_time)
+    def timeout_download_fun():
+        return download_speed_test(
+            n_bytes=n_bytes,
+            proxies=proxies,
+            timeout=test_config.max_dl_latency,
         )
-        log.debug(
-          "Upload test successful",
-          extra={
-            "ip": ip,
-            "cidr": cidr,
-            "up_speed": up_speed,
-            "up_latency": up_latency,
-          },
-        )
-      except requests.exceptions.ReadTimeout:
-        fail_msg = no_and_kill(ip, "upload read timeout", process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
-      except requests.exceptions.ConnectTimeout:
-        fail_msg = no_and_kill(ip, "upload connect timeout", process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
-      except requests.exceptions.ConnectionError:
-        fail_msg = no_and_kill(ip, "upload connection error", process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
-      except Exception as e:
-        log.exception(
-          e,
-          extra={"ip": ip, "cidr": cidr},
-        )
-        log.error(
-          f"Upload unknown error: {e}",
-          extra={
-            "ip": ip,
-          },
-        )
-        fail_msg = no_and_kill(ip, "Upload unknown error", process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
 
-      if up_latency > test_config.max_ul_latency:
-        fail_msg = no_and_kill(ip, "upload latency too high", process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
-      up_speed_kBps = up_speed / 8 * 1000
-      if up_speed_kBps >= test_config.min_ul_speed:
-        test_result.result["upload"]["speed"][try_idx] = up_speed
-        test_result.result["upload"]["latency"][try_idx] = round(up_latency * 1000)
-      else:
-        message = f"upload too slow {up_speed_kBps:.2f} kBps < {test_config.min_ul_speed:.2f} kBps"
-        fail_msg = no_and_kill(ip, message, process)
-        test_result.message = fail_msg
-        test_result.is_ok = False
-        return test_result
+    for try_idx in range(test_config.n_tries):
+        # check download speed
+        n_bytes = test_config.min_dl_speed * 1000 * test_config.max_dl_time
+        try:
+            dl_speed, dl_latency = timeout_download_fun()
+        except TimeoutError:
+            fail_msg = no_and_kill(ip=ip, message="download timeout exceeded", process=process)
+            log.debug(
+                "Timeout in dl test",
+                extra={"ip": ip, "cidr": cidr},
+            )
+            test_result.message = fail_msg
+            test_result.is_ok = False
+            return test_result
+        except (
+            requests.exceptions.ReadTimeout,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectTimeout,
+        ) as e:
+            log.debug("Requests error in dl test", extra={"ip": ip, "cidr": cidr, "error": str(e)})
+            fail_msg = no_and_kill(ip=ip, message="download error", process=process)
+            test_result.message = fail_msg
+            test_result.is_ok = False
+            return test_result
+        except Exception as e:
+            log.exception(e)
+            log.error(
+                f"Download unknown error: {e}",
+                extra={
+                    "ip": ip,
+                    "cidr": cidr,
+                },
+            )
+            fail_msg = no_and_kill(ip=ip, message="download unknown error", process=process)
+            test_result.message = fail_msg
+            test_result.is_ok = False
+            return test_result
 
-  process.kill()
+        if dl_latency <= test_config.max_dl_latency:
+            log.debug(
+                "dl_latency acceptable",
+                extra={
+                    "ip": ip,
+                    "cidr": cidr,
+                    "dl_latency": dl_latency,
+                    "max_acceptable": test_config.max_dl_latency,
+                },
+            )
+            dl_speed_kBps = dl_speed / 8 * 1000
+            if dl_speed_kBps >= test_config.min_dl_speed:
+                test_result.result["download"]["speed"][try_idx] = dl_speed
+                test_result.result["download"]["latency"][try_idx] = round(dl_latency * 1000)
+            else:
+                log.debug(
+                    "download speed too low",
+                    extra={"ip": ip, "cidr": cidr, "dl_speed_kBps": dl_speed_kBps},
+                )
+                message = (
+                    f"download too slow {dl_speed_kBps:.2f} < {test_config.min_dl_speed:.2f} kBps"
+                )
+                fail_msg = no_and_kill(ip=ip, message=message, process=process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
+        else:
+            message = (
+                f"high download latency {dl_latency:.4f} s > {test_config.max_dl_latency:.4f} s"
+            )
+            fail_msg = no_and_kill(ip=ip, message=message, process=process)
+            test_result.message = fail_msg
+            test_result.is_ok = False
+            return test_result
 
-  test_ok_msg = ok_message(test_result.result)
+        # upload speed test
+        if test_config.do_upload_test:
+            n_bytes = test_config.min_ul_speed * 1000 * test_config.max_ul_time
+            try:
+                up_speed, up_latency = upload_speed_test(
+                    n_bytes=n_bytes,
+                    proxies=proxies,
+                    timeout=test_config.max_ul_latency + test_config.max_ul_time,
+                )
+                log.debug(
+                    "Upload test successful",
+                    extra={
+                        "ip": ip,
+                        "cidr": cidr,
+                        "up_speed": up_speed,
+                        "up_latency": up_latency,
+                    },
+                )
+            except requests.exceptions.ReadTimeout:
+                fail_msg = no_and_kill(ip, "upload read timeout", process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
+            except requests.exceptions.ConnectTimeout:
+                fail_msg = no_and_kill(ip, "upload connect timeout", process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
+            except requests.exceptions.ConnectionError:
+                fail_msg = no_and_kill(ip, "upload connection error", process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
+            except Exception as e:
+                log.exception(
+                    e,
+                    extra={"ip": ip, "cidr": cidr},
+                )
+                log.error(
+                    f"Upload unknown error: {e}",
+                    extra={
+                        "ip": ip,
+                    },
+                )
+                fail_msg = no_and_kill(ip, "Upload unknown error", process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
 
-  test_result.is_ok = True
-  test_result.message = test_ok_msg
-  return test_result
+            if up_latency > test_config.max_ul_latency:
+                fail_msg = no_and_kill(ip, "upload latency too high", process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
+            up_speed_kBps = up_speed / 8 * 1000
+            if up_speed_kBps >= test_config.min_ul_speed:
+                test_result.result["upload"]["speed"][try_idx] = up_speed
+                test_result.result["upload"]["latency"][try_idx] = round(up_latency * 1000)
+            else:
+                message = f"upload too slow {up_speed_kBps:.2f} kBps < {test_config.min_ul_speed:.2f} kBps"
+                fail_msg = no_and_kill(ip, message, process)
+                test_result.message = fail_msg
+                test_result.is_ok = False
+                return test_result
+
+    process.kill()
+
+    test_ok_msg = ok_message(test_result.result)
+
+    test_result.is_ok = True
+    test_result.message = test_ok_msg
+    return test_result

--- a/python/src/cfscanner/speedtest/conduct.py
+++ b/python/src/cfscanner/speedtest/conduct.py
@@ -16,210 +16,221 @@ log = logging.getLogger(__name__)
 
 
 class TestResult:
-    """class to store test results"""
+  """class to store test results"""
 
-    def __init__(self, ip, cidr, n_tries):
-        self.ip = ip
-        self.cidr = cidr
+  def __init__(self, ip, cidr, n_tries):
+    self.ip = ip
+    self.cidr = cidr
 
-        self.is_ok = False
-        self.n_tries = n_tries
-        self.message = ""
+    self.is_ok = False
+    self.n_tries = n_tries
+    self.message = ""
 
-        self.result = dict(
-            ip=ip,
-            success=False,
-            download=dict(
-                speed=[-1] * self.n_tries, latency=[-1] * self.n_tries
-            ),
-            upload=dict(
-                speed=[-1] * self.n_tries, latency=[-1] * self.n_tries
-            ),
-        )
+    self.result = dict(
+      ip=ip,
+      success=False,
+      download=dict(speed=[-1] * self.n_tries, latency=[-1] * self.n_tries),
+      upload=dict(speed=[-1] * self.n_tries, latency=[-1] * self.n_tries),
+    )
 
-    def __bool__(self):
-        return self.is_ok
+  def __bool__(self):
+    return self.is_ok
 
 
 class _FakeProcess:
-    def __init__(self):
-        pass
+  def __init__(self):
+    pass
 
-    def kill(self):
-        pass
+  def kill(self):
+    pass
 
 
 def test_ip(ip_cidr: tuple, test_config: TestConfig, config_dir: str):
-    ip, cidr = ip_cidr
-    test_result = TestResult(ip=ip, cidr=cidr, n_tries=test_config.n_tries)
+  ip, cidr = ip_cidr
+  test_result = TestResult(ip=ip, cidr=cidr, n_tries=test_config.n_tries)
 
-    if not test_config.no_fronting:
-        for try_idx in range(test_config.n_tries):
-            fronting_result_msg = fronting_test(
-                ip, timeout=test_config.fronting_timeout
-            )
-            if "NO" in fronting_result_msg:
-                test_result.message = fronting_result_msg
-                test_result.is_ok = False
-                return test_result
-
-    if not test_config.novpn:
-        try:
-            proxy_config_path = create_proxy_config(
-                edge_ip=ip, test_config=test_config, config_dir=config_dir
-            )
-        except Exception:
-            test_result.message = no_and_kill(
-                ip=ip,
-                message="Could not save proxy (xray/v2ray) config to file",
-                process=_FakeProcess(),
-            )
-            test_result.is_ok = False
-            return test_result
-
-    if not test_config.novpn:
-        try:
-            process, proxies = start_proxy_service(
-                proxy_conf_path=proxy_config_path,
-                binary_path=test_config.binpath,
-                timeout=test_config.startprocess_timeout,
-            )
-        except Exception:
-            test_result.is_ok = False
-            raise StartProxyServiceError(
-                f"Could not start xray service - {ip}"
-            )
-
-    else:
-        process = _FakeProcess()
-        proxies = None
-
-    @timeout_fun(test_config.max_dl_latency + test_config.max_dl_time)
-    def timeout_download_fun():
-        return download_speed_test(
-            n_bytes=n_bytes,
-            proxies=proxies,
-            timeout=test_config.max_dl_latency,
-        )
-
+  if not test_config.no_fronting:
     for try_idx in range(test_config.n_tries):
-        # check download speed
-        n_bytes = test_config.min_dl_speed * 1000 * test_config.max_dl_time
-        try:
-            dl_speed, dl_latency = timeout_download_fun()
-        except TimeoutError:
-            fail_msg = no_and_kill(
-                ip=ip, message="download timeout exceeded", process=process
-            )
-            test_result.message = fail_msg
-            test_result.is_ok = False
-            return test_result
-        except (
-            requests.exceptions.ReadTimeout,
-            requests.exceptions.ConnectionError,
-            requests.ConnectTimeout,
-        ):
-            fail_msg = no_and_kill(
-                ip=ip, message="download error", process=process
-            )
-            test_result.message = fail_msg
-            test_result.is_ok = False
-            return test_result
-        except Exception as e:
-            log.exception(e)
-            log.error(
-                f"Download unknown error: {e}",
-                extra={
-                    "ip": ip,
-                },
-            )
-            fail_msg = no_and_kill(
-                ip=ip, message="download unknown error", process=process
-            )
-            test_result.message = fail_msg
-            test_result.is_ok = False
-            return test_result
+      fronting_result_msg = fronting_test(ip, timeout=test_config.fronting_timeout)
+      if "NO" in fronting_result_msg:
+        test_result.message = fronting_result_msg
+        test_result.is_ok = False
+        return test_result
 
-        if dl_latency <= test_config.max_dl_latency:
-            dl_speed_kBps = dl_speed / 8 * 1000
-            if dl_speed_kBps >= test_config.min_dl_speed:
-                test_result.result["download"]["speed"][try_idx] = dl_speed
-                test_result.result["download"]["latency"][try_idx] = round(
-                    dl_latency * 1000
-                )
-            else:
-                message = f"download too slow {dl_speed_kBps:.2f} < {test_config.min_dl_speed:.2f} kBps"
-                fail_msg = no_and_kill(ip=ip, message=message, process=process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
-        else:
-            message = f"high download latency {dl_latency:.4f} s > {test_config.max_dl_latency:.4f} s"
-            fail_msg = no_and_kill(ip=ip, message=message, process=process)
-            test_result.message = fail_msg
-            test_result.is_ok = False
-            return test_result
+  if not test_config.novpn:
+    try:
+      proxy_config_path = create_proxy_config(
+        edge_ip=ip, test_config=test_config, config_dir=config_dir
+      )
+    except Exception:
+      test_result.message = no_and_kill(
+        ip=ip,
+        message="Could not save proxy (xray/v2ray) config to file",
+        process=_FakeProcess(),
+      )
+      test_result.is_ok = False
+      return test_result
 
-        # upload speed test
-        if test_config.do_upload_test:
-            n_bytes = test_config.min_ul_speed * 1000 * test_config.max_ul_time
-            try:
-                up_speed, up_latency = upload_speed_test(
-                    n_bytes=n_bytes,
-                    proxies=proxies,
-                    timeout=test_config.max_ul_latency
-                    + test_config.max_ul_time,
-                )
-            except requests.exceptions.ReadTimeout:
-                fail_msg = no_and_kill(ip, "upload read timeout", process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
-            except requests.exceptions.ConnectTimeout:
-                fail_msg = no_and_kill(ip, "upload connect timeout", process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
-            except requests.exceptions.ConnectionError:
-                fail_msg = no_and_kill(ip, "upload connection error", process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
-            except Exception as e:
-                log.exception(e)
-                log.error(
-                    f"Upload unknown error: {e}",
-                    extra={
-                        "ip": ip,
-                    },
-                )
-                fail_msg = no_and_kill(ip, "Upload unknown error", process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
+  if not test_config.novpn:
+    try:
+      process, proxies = start_proxy_service(
+        proxy_conf_path=proxy_config_path,
+        binary_path=test_config.binpath,
+        timeout=test_config.startprocess_timeout,
+      )
+    except Exception:
+      test_result.is_ok = False
+      raise StartProxyServiceError(f"Could not start xray service - {ip}")
 
-            if up_latency > test_config.max_ul_latency:
-                fail_msg = no_and_kill(ip, "upload latency too high", process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
-            up_speed_kBps = up_speed / 8 * 1000
-            if up_speed_kBps >= test_config.min_ul_speed:
-                test_result.result["upload"]["speed"][try_idx] = up_speed
-                test_result.result["upload"]["latency"][try_idx] = round(
-                    up_latency * 1000
-                )
-            else:
-                message = f"upload too slow {up_speed_kBps:.2f} kBps < {test_config.min_ul_speed:.2f} kBps"
-                fail_msg = no_and_kill(ip, message, process)
-                test_result.message = fail_msg
-                test_result.is_ok = False
-                return test_result
+  else:
+    process = _FakeProcess()
+    proxies = None
 
-    process.kill()
+  @timeout_fun(test_config.max_dl_latency + test_config.max_dl_time)
+  def timeout_download_fun():
+    return download_speed_test(
+      n_bytes=n_bytes,
+      proxies=proxies,
+      timeout=test_config.max_dl_latency,
+    )
 
-    test_ok_msg = ok_message(test_result.result)
+  for try_idx in range(test_config.n_tries):
+    # check download speed
+    n_bytes = test_config.min_dl_speed * 1000 * test_config.max_dl_time
+    try:
+      dl_speed, dl_latency = timeout_download_fun()
+    except TimeoutError:
+      fail_msg = no_and_kill(
+        ip=ip, message="download timeout exceeded", process=process
+      )
+      log.debug(
+        "Timeout in dl test",
+        extra={"ip": ip, "cidr": cidr, "dl_speed": dl_speed, "dl_latency": dl_latency},
+      )
+      test_result.message = fail_msg
+      test_result.is_ok = False
+      return test_result
+    except (
+      requests.exceptions.ReadTimeout,
+      requests.exceptions.ConnectionError,
+      requests.ConnectTimeout,
+    ) as e:
+      log.debug(
+        "Requests error in dl test", extra={"ip": ip, "cidr": cidr, "error": str(e)}
+      )
+      fail_msg = no_and_kill(ip=ip, message="download error", process=process)
+      test_result.message = fail_msg
+      test_result.is_ok = False
+      return test_result
+    except Exception as e:
+      log.exception(e)
+      log.error(
+        f"Download unknown error: {e}",
+        extra={
+          "ip": ip,
+          "cidr": cidr,
+        },
+      )
+      fail_msg = no_and_kill(ip=ip, message="download unknown error", process=process)
+      test_result.message = fail_msg
+      test_result.is_ok = False
+      return test_result
 
-    test_result.is_ok = True
-    test_result.message = test_ok_msg
-    return test_result
+    if dl_latency <= test_config.max_dl_latency:
+      log.debug(
+        "dl_latency acceptable",
+        extra={
+          "ip": ip,
+          "cidr": cidr,
+          "dl_latency": dl_latency,
+          "max_acceptable": test_config.max_dl_latency,
+        },
+      )
+      dl_speed_kBps = dl_speed / 8 * 1000
+      if dl_speed_kBps >= test_config.min_dl_speed:
+        test_result.result["download"]["speed"][try_idx] = dl_speed
+        test_result.result["download"]["latency"][try_idx] = round(dl_latency * 1000)
+      else:
+        log.debug(
+          "download speed too low",
+          extra={"ip": ip, "cidr": cidr, "dl_speed_kBps": dl_speed_kBps},
+        )
+        message = (
+          f"download too slow {dl_speed_kBps:.2f} < {test_config.min_dl_speed:.2f} kBps"
+        )
+        fail_msg = no_and_kill(ip=ip, message=message, process=process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+    else:
+      message = (
+        f"high download latency {dl_latency:.4f} s > {test_config.max_dl_latency:.4f} s"
+      )
+      fail_msg = no_and_kill(ip=ip, message=message, process=process)
+      test_result.message = fail_msg
+      test_result.is_ok = False
+      return test_result
+
+    # upload speed test
+    if test_config.do_upload_test:
+      n_bytes = test_config.min_ul_speed * 1000 * test_config.max_ul_time
+      try:
+        up_speed, up_latency = upload_speed_test(
+          n_bytes=n_bytes,
+          proxies=proxies,
+          timeout=test_config.max_ul_latency + test_config.max_ul_time,
+        )
+      except requests.exceptions.ReadTimeout:
+        fail_msg = no_and_kill(ip, "upload read timeout", process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+      except requests.exceptions.ConnectTimeout:
+        fail_msg = no_and_kill(ip, "upload connect timeout", process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+      except requests.exceptions.ConnectionError:
+        fail_msg = no_and_kill(ip, "upload connection error", process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+      except Exception as e:
+        log.exception(
+          e,
+          extra={"ip": ip, "cidr": cidr},
+        )
+        log.error(
+          f"Upload unknown error: {e}",
+          extra={
+            "ip": ip,
+          },
+        )
+        fail_msg = no_and_kill(ip, "Upload unknown error", process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+
+      if up_latency > test_config.max_ul_latency:
+        fail_msg = no_and_kill(ip, "upload latency too high", process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+      up_speed_kBps = up_speed / 8 * 1000
+      if up_speed_kBps >= test_config.min_ul_speed:
+        test_result.result["upload"]["speed"][try_idx] = up_speed
+        test_result.result["upload"]["latency"][try_idx] = round(up_latency * 1000)
+      else:
+        message = f"upload too slow {up_speed_kBps:.2f} kBps < {test_config.min_ul_speed:.2f} kBps"
+        fail_msg = no_and_kill(ip, message, process)
+        test_result.message = fail_msg
+        test_result.is_ok = False
+        return test_result
+
+  process.kill()
+
+  test_ok_msg = ok_message(test_result.result)
+
+  test_result.is_ok = True
+  test_result.message = test_ok_msg
+  return test_result

--- a/python/src/cfscanner/speedtest/conduct.py
+++ b/python/src/cfscanner/speedtest/conduct.py
@@ -180,6 +180,15 @@ def test_ip(ip_cidr: tuple, test_config: TestConfig, config_dir: str):
           proxies=proxies,
           timeout=test_config.max_ul_latency + test_config.max_ul_time,
         )
+        log.debug(
+          "Upload test successful",
+          extra={
+            "ip": ip,
+            "cidr": cidr,
+            "up_speed": up_speed,
+            "up_latency": up_latency,
+          },
+        )
       except requests.exceptions.ReadTimeout:
         fail_msg = no_and_kill(ip, "upload read timeout", process)
         test_result.message = fail_msg

--- a/python/src/cfscanner/speedtest/download.py
+++ b/python/src/cfscanner/speedtest/download.py
@@ -9,45 +9,52 @@ log = logging.getLogger(__name__)
 
 
 def download_speed_test(
-    n_bytes: int, proxies: dict, timeout: int
+  n_bytes: int, proxies: dict, timeout: int
 ) -> Tuple[float, float]:
-    """tests the download speed using cloudflare servers
+  """tests the download speed using cloudflare servers
 
-    Args:
-        n_bytes (int): size of file to download in bytes
-        proxies (dict): the proxies to use for ``requests.get``
-        timeout (int): the timeout for the download request
+  Args:
+      n_bytes (int): size of file to download in bytes
+      proxies (dict): the proxies to use for ``requests.get``
+      timeout (int): the timeout for the download request
 
-    Returns:
-        download_speed (float): the download speed in megabit per second
-        latency (float): the round trip time latency in seconds
-    """
-    start_time = time.perf_counter()
-    r = requests.get(
-        url="https://speed.cloudflare.com/__down",
-        params={"bytes": n_bytes},
-        timeout=timeout,
-        proxies=proxies,
+  Returns:
+      download_speed (float): the download speed in megabit per second
+      latency (float): the round trip time latency in seconds
+  """
+  log.debug("Starting download test", extra={"n_bytes": n_bytes, "timeout": timeout})
+  start_time = time.perf_counter()
+  r = requests.get(
+    url="https://speed.cloudflare.com/__down",
+    params={"bytes": n_bytes},
+    timeout=timeout,
+    proxies=proxies,
+  )
+  log.debug("Received response", extra={"content": r.content})
+  total_time = time.perf_counter() - start_time
+
+  server_timing_header = r.headers.get("Server-Timing")
+  pattern = r"dur=(\d*\.\d+)"
+  match = re.search(pattern, server_timing_header)
+  if match:
+    cf_time = float(match.group(1)) / 1000
+  else:
+    msg = f"Cannot parse CF header: {server_timing_header}"
+    log.error(
+      msg,
+      extra={"header": server_timing_header},
     )
-    total_time = time.perf_counter() - start_time
+    raise ValueError(msg)
 
-    server_timing_header = r.headers.get("Server-Timing")
-    pattern = r"dur=(\d*\.\d+)"
-    match = re.search(pattern, server_timing_header)
-    if match:
-        cf_time = float(match.group(1)) / 1000
-    else:
-        msg = f"Cannot parse CF header: {server_timing_header}"
-        log.error(
-            msg,
-            extra={"header": server_timing_header},
-        )
-        raise ValueError(msg)
+  latency = r.elapsed.total_seconds() - cf_time
+  download_time = total_time - latency
 
-    latency = r.elapsed.total_seconds() - cf_time
-    download_time = total_time - latency
+  mb = n_bytes * 8 / (10**6)
+  download_speed = mb / download_time
 
-    mb = n_bytes * 8 / (10**6)
-    download_speed = mb / download_time
+  log.debug(
+    "Download speed calculated",
+    extra={"download_speed": download_speed, "latency": latency},
+  )
 
-    return download_speed, latency
+  return download_speed, latency

--- a/python/src/cfscanner/speedtest/download.py
+++ b/python/src/cfscanner/speedtest/download.py
@@ -8,53 +8,50 @@ import requests
 log = logging.getLogger(__name__)
 
 
-def download_speed_test(
-  n_bytes: int, proxies: dict, timeout: int
-) -> Tuple[float, float]:
-  """tests the download speed using cloudflare servers
+def download_speed_test(n_bytes: int, proxies: dict, timeout: int) -> Tuple[float, float]:
+    """tests the download speed using cloudflare servers
 
-  Args:
-      n_bytes (int): size of file to download in bytes
-      proxies (dict): the proxies to use for ``requests.get``
-      timeout (int): the timeout for the download request
+    Args:
+        n_bytes (int): size of file to download in bytes
+        proxies (dict): the proxies to use for ``requests.get``
+        timeout (int): the timeout for the download request
 
-  Returns:
-      download_speed (float): the download speed in megabit per second
-      latency (float): the round trip time latency in seconds
-  """
-  log.debug("Starting download test", extra={"n_bytes": n_bytes, "timeout": timeout})
-  start_time = time.perf_counter()
-  r = requests.get(
-    url="https://speed.cloudflare.com/__down",
-    params={"bytes": n_bytes},
-    timeout=timeout,
-    proxies=proxies,
-  )
-  log.debug("Received response", extra={"content": r.content})
-  total_time = time.perf_counter() - start_time
-
-  server_timing_header = r.headers.get("Server-Timing")
-  pattern = r"dur=(\d+(?:\.\d+)?)"
-  match = re.search(pattern, server_timing_header)
-  if match:
-    cf_time = float(match.group(1)) / 1000
-  else:
-    msg = f"Cannot parse CF header: {server_timing_header}"
-    log.error(
-      msg,
-      extra={"header": server_timing_header},
+    Returns:
+        download_speed (float): the download speed in megabit per second
+        latency (float): the round trip time latency in seconds
+    """
+    log.debug("Starting download test", extra={"n_bytes": n_bytes, "timeout": timeout})
+    start_time = time.perf_counter()
+    r = requests.get(
+        url="https://speed.cloudflare.com/__down",
+        params={"bytes": n_bytes},
+        timeout=timeout,
+        proxies=proxies,
     )
-    raise ValueError(msg)
+    total_time = time.perf_counter() - start_time
 
-  latency = r.elapsed.total_seconds() - cf_time
-  download_time = total_time - latency
+    server_timing_header = r.headers.get("Server-Timing")
+    pattern = r"dur=(\d+(?:\.\d+)?)"
+    match = re.search(pattern, server_timing_header) if server_timing_header else None
+    if match:
+        cf_time = float(match.group(1)) / 1000
+    else:
+        msg = f"Cannot parse CF header: {server_timing_header}"
+        log.error(
+            msg,
+            extra={"header": server_timing_header},
+        )
+        raise ValueError(msg)
 
-  mb = n_bytes * 8 / (10**6)
-  download_speed = mb / download_time
+    latency = r.elapsed.total_seconds() - cf_time
+    download_time = total_time - latency
 
-  log.debug(
-    "Download speed calculated",
-    extra={"download_speed": download_speed, "latency": latency},
-  )
+    mb = n_bytes * 8 / (10**6)
+    download_speed = mb / download_time
 
-  return download_speed, latency
+    log.debug(
+        "Download speed calculated",
+        extra={"download_speed": download_speed, "latency": latency},
+    )
+
+    return download_speed, latency

--- a/python/src/cfscanner/speedtest/download.py
+++ b/python/src/cfscanner/speedtest/download.py
@@ -34,7 +34,7 @@ def download_speed_test(
   total_time = time.perf_counter() - start_time
 
   server_timing_header = r.headers.get("Server-Timing")
-  pattern = r"dur=(\d*\.\d+)"
+  pattern = r"dur=(\d+(?:\.\d+)?)"
   match = re.search(pattern, server_timing_header)
   if match:
     cf_time = float(match.group(1)) / 1000

--- a/python/src/cfscanner/speedtest/fronting.py
+++ b/python/src/cfscanner/speedtest/fronting.py
@@ -1,7 +1,7 @@
+import logging
 import re
 
 import requests
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/python/src/cfscanner/speedtest/upload.py
+++ b/python/src/cfscanner/speedtest/upload.py
@@ -9,49 +9,49 @@ log = logging.getLogger(__name__)
 
 
 def upload_speed_test(
-  n_bytes: int,
-  proxies: dict,
-  timeout: int,
+    n_bytes: int,
+    proxies: dict,
+    timeout: int,
 ) -> Tuple[float, float]:
-  """tests the upload speed using cloudflare servers
+    """tests the upload speed using cloudflare servers
 
-  Args:
-      n_bytes (int): size of file to upload in bytes
-      proxies (dict): the proxies to use for ``requests.post``
-      timeout (int): the timeout for the download ``requests.post``
+    Args:
+        n_bytes (int): size of file to upload in bytes
+        proxies (dict): the proxies to use for ``requests.post``
+        timeout (int): the timeout for the download ``requests.post``
 
-  Returns:
-      upload_speed (float): the upload speed in mbps
-      latency (float): the round trip time latency in seconds
-  """
+    Returns:
+        upload_speed (float): the upload speed in mbps
+        latency (float): the round trip time latency in seconds
+    """
 
-  start_time = time.perf_counter()
-  r = requests.post(
-    url="https://speed.cloudflare.com/__up",
-    data="0" * n_bytes,
-    timeout=timeout,
-    proxies=proxies,
-  )
-  total_time = time.perf_counter() - start_time
-
-  server_timing_header = r.headers.get("Server-Timing")
-  pattern = r"dur=(\d*\.\d+)"
-  match = re.search(pattern, server_timing_header)
-  if match:
-    cf_time = float(match.group(1)) / 1000
-  else:
-    msg = f"Cannot parse CF header: {server_timing_header}"
-    log.error(
-      msg,
-      extra={"header": server_timing_header},
+    start_time = time.perf_counter()
+    r = requests.post(
+        url="https://speed.cloudflare.com/__up",
+        data="0" * n_bytes,
+        timeout=timeout,
+        proxies=proxies,
     )
-    raise ValueError(msg)
+    total_time = time.perf_counter() - start_time
 
-  latency = total_time - cf_time
-  log.debug(f"Upload latency {latency}")
+    server_timing_header = r.headers.get("Server-Timing")
+    pattern = r"dur=(\d+(?:\.\d+)?)"
+    match = re.search(pattern, server_timing_header) if server_timing_header else None
+    if match:
+        cf_time = float(match.group(1)) / 1000
+    else:
+        msg = f"Cannot parse CF header: {server_timing_header}"
+        log.error(
+            msg,
+            extra={"header": server_timing_header},
+        )
+        raise ValueError(msg)
 
-  mb = n_bytes * 8 / (10**6)
-  upload_speed = mb / cf_time
-  log.debug(f"Upload speed {upload_speed}")
+    latency = total_time - cf_time
+    log.debug(f"Upload latency {latency}")
 
-  return upload_speed, latency
+    mb = n_bytes * 8 / (10**6)
+    upload_speed = mb / cf_time
+    log.debug(f"Upload speed {upload_speed}")
+
+    return upload_speed, latency

--- a/python/src/cfscanner/speedtest/upload.py
+++ b/python/src/cfscanner/speedtest/upload.py
@@ -1,4 +1,3 @@
-from ipaddress import ip_address
 import logging
 import re
 import time

--- a/python/src/cfscanner/speedtest/upload.py
+++ b/python/src/cfscanner/speedtest/upload.py
@@ -1,3 +1,4 @@
+from ipaddress import ip_address
 import logging
 import re
 import time
@@ -9,47 +10,49 @@ log = logging.getLogger(__name__)
 
 
 def upload_speed_test(
-    n_bytes: int,
-    proxies: dict,
-    timeout: int,
+  n_bytes: int,
+  proxies: dict,
+  timeout: int,
 ) -> Tuple[float, float]:
-    """tests the upload speed using cloudflare servers
+  """tests the upload speed using cloudflare servers
 
-    Args:
-        n_bytes (int): size of file to upload in bytes
-        proxies (dict): the proxies to use for ``requests.post``
-        timeout (int): the timeout for the download ``requests.post``
+  Args:
+      n_bytes (int): size of file to upload in bytes
+      proxies (dict): the proxies to use for ``requests.post``
+      timeout (int): the timeout for the download ``requests.post``
 
-    Returns:
-        upload_speed (float): the upload speed in mbps
-        latency (float): the round trip time latency in seconds
-    """
+  Returns:
+      upload_speed (float): the upload speed in mbps
+      latency (float): the round trip time latency in seconds
+  """
 
-    start_time = time.perf_counter()
-    r = requests.post(
-        url="https://speed.cloudflare.com/__up",
-        data="0" * n_bytes,
-        timeout=timeout,
-        proxies=proxies,
+  start_time = time.perf_counter()
+  r = requests.post(
+    url="https://speed.cloudflare.com/__up",
+    data="0" * n_bytes,
+    timeout=timeout,
+    proxies=proxies,
+  )
+  total_time = time.perf_counter() - start_time
+
+  server_timing_header = r.headers.get("Server-Timing")
+  pattern = r"dur=(\d*\.\d+)"
+  match = re.search(pattern, server_timing_header)
+  if match:
+    cf_time = float(match.group(1)) / 1000
+  else:
+    msg = f"Cannot parse CF header: {server_timing_header}"
+    log.error(
+      msg,
+      extra={"header": server_timing_header},
     )
-    total_time = time.perf_counter() - start_time
+    raise ValueError(msg)
 
-    server_timing_header = r.headers.get("Server-Timing")
-    pattern = r"dur=(\d*\.\d+)"
-    match = re.search(pattern, server_timing_header)
-    if match:
-        cf_time = float(match.group(1)) / 1000
-    else:
-        msg = f"Cannot parse CF header: {server_timing_header}"
-        log.error(
-            msg,
-            extra={"header": server_timing_header},
-        )
-        raise ValueError(msg)
+  latency = total_time - cf_time
+  log.debug(f"Upload latency {latency}")
 
-    latency = total_time - cf_time
+  mb = n_bytes * 8 / (10**6)
+  upload_speed = mb / cf_time
+  log.debug(f"Upload speed {upload_speed}")
 
-    mb = n_bytes * 8 / (10**6)
-    upload_speed = mb / cf_time
-
-    return upload_speed, latency
+  return upload_speed, latency

--- a/python/src/cfscanner/subnets/cidr.py
+++ b/python/src/cfscanner/subnets/cidr.py
@@ -95,8 +95,10 @@ def read_cidrs_from_url(url: str, timeout: float = 10) -> list:
         cidrs = re.findall(cidr_regex, r.text)
         if len(cidrs) == 0:
             raise SubnetsReadError(f"Could not find any cidr in url {url}")
-    except Exception:
-        raise SubnetsReadError(f'Could not read cidrs from url "{url}"')
+    except SubnetsReadError:
+        raise
+    except Exception as err:
+        raise SubnetsReadError(f'Could not read cidrs from url "{url}"') from err
 
     return cidrs
 
@@ -121,12 +123,12 @@ def read_cidrs_from_file(filepath: str, shuffle: bool = False, n_lines: int = No
                 if line.strip():
                     yield line.strip()
         else:
-            with open(filepath, "r") as f:
+            with open(filepath) as f:
                 for line in f:
                     yield line.strip()
 
-    except Exception:
-        raise SubnetsReadError(f"Could not read cidrs from file {filepath}")
+    except Exception as err:
+        raise SubnetsReadError(f"Could not read cidrs from file {filepath}") from err
 
 
 def read_cidrs(

--- a/python/src/cfscanner/utils/os.py
+++ b/python/src/cfscanner/utils/os.py
@@ -62,7 +62,7 @@ def detect_system() -> tuple:
             return ("macos", "64")
     # add other systems as needed
     else:
-        raise OSError("Unsupported system: {current_system}")
+        raise OSError(f"Unsupported system: {current_system}")
 
 
 def create_dir(dir_path):

--- a/python/src/cfscanner/utils/requests.py
+++ b/python/src/cfscanner/utils/requests.py
@@ -1,6 +1,7 @@
 import requests
-from ..utils.exceptions import FileDownloadError
+
 from ..report.logging_setup import console
+from ..utils.exceptions import FileDownloadError
 
 
 def download_file(
@@ -19,7 +20,7 @@ def download_file(
             for chunk in r.iter_content(chunk_size=chunk_size):
                 if chunk:
                     zip_out.write(chunk)
-    except Exception:
+    except Exception as err:
         console.print_exception()
-        raise (FileDownloadError(f"Error downloading file from {url} to {save_path}"))
+        raise FileDownloadError(f"Error downloading file from {url} to {save_path}") from err
     return True

--- a/python/src/cfscanner/xray/binary.py
+++ b/python/src/cfscanner/xray/binary.py
@@ -64,18 +64,18 @@ def download_binary(
                     binoutfile.write(xray_file)
                 os.chmod(bin_path, 0o775)
                 return bin_path
-            except FileDownloadError:
+            except FileDownloadError as err:
                 raise BinaryDownloadError(
                     f"Failed to download the release zip file from xtls xray-core github repo {system_info}"
-                )
-            except KeyError:
+                ) from err
+            except KeyError as err:
                 raise BinaryDownloadError(
                     f"Failed to get binary from zip file {zip_url}"
-                )
-            except Exception:
+                ) from err
+            except Exception as err:
                 raise BinaryDownloadError(
                     f"Unknown error - detected system: {system_info}"
-                )
+                ) from err
     else:
         console.log(f"[bright_blue]Binary file already exists {bin_path}[/bright_blue]")
         return bin_path

--- a/python/src/cfscanner/xray/config.py
+++ b/python/src/cfscanner/xray/config.py
@@ -1,8 +1,8 @@
 import os
+import uuid
 
 from ..args.testconfig import TestConfig
 from ..utils.socket import get_free_port
-import uuid
 
 
 def create_proxy_config(

--- a/python/src/cfscanner/xray/service.py
+++ b/python/src/cfscanner/xray/service.py
@@ -20,7 +20,7 @@ def start_proxy_service(
     Returns:
         Tuple[subprocess.Popen, dict]: the v2ray process object and a dictionary containing the proxies to use with ``requests.get``
     """
-    with open(proxy_conf_path, "r") as infile:
+    with open(proxy_conf_path) as infile:
         proxy_conf = json.load(infile)
 
     proxy_listen = proxy_conf["inbounds"][0].get("listen", "127.0.0.1")

--- a/python/tests/test_main_module.py
+++ b/python/tests/test_main_module.py
@@ -1,0 +1,23 @@
+import ast
+import pathlib
+import warnings
+
+MAIN_PY = pathlib.Path(__file__).parent.parent / "src" / "cfscanner" / "main.py"
+
+
+def test_main_module_compiles_without_syntax_warnings():
+    """``main.py`` must not contain invalid escape sequences in string literals.
+
+    Regression test for the ASCII-art logo being defined as a plain (non-raw)
+    triple-quoted string containing backslashes, which raises a
+    ``SyntaxWarning`` today and will become a ``SyntaxError`` in a future
+    CPython version.
+    """
+    source = MAIN_PY.read_text()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        compile(source, str(MAIN_PY), "exec", ast.PyCF_ONLY_AST)
+
+    syntax_warnings = [w for w in caught if issubclass(w.category, SyntaxWarning)]
+    assert not syntax_warnings, [str(w.message) for w in syntax_warnings]

--- a/python/tests/test_speedtest_download.py
+++ b/python/tests/test_speedtest_download.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+
+from cfscanner.speedtest import download
+
+
+def test_download_speed_accepts_integer_server_timing_duration(monkeypatch):
+    """Cloudflare emits integer ``dur`` values, not only decimal ones."""
+
+    class Response:
+        headers = {
+            "Server-Timing": (
+                'cfSpeedEdge;dur=4, cfSpeedWorker;dur=28, '
+                'cfL4;desc="?proto=TCP&rtt=0"'
+            )
+        }
+        elapsed = timedelta(milliseconds=50)
+        content = b"x"
+
+    monkeypatch.setattr(download.requests, "get", lambda **kwargs: Response())
+    monkeypatch.setattr(download.time, "perf_counter", iter([10.0, 10.1]).__next__)
+
+    speed, latency = download.download_speed_test(
+        n_bytes=1_000,
+        proxies={"https": "socks5://127.0.0.1:12345"},
+        timeout=8,
+    )
+
+    assert speed > 0
+    assert latency == 0.046

--- a/python/tests/test_speedtest_download.py
+++ b/python/tests/test_speedtest_download.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+import pytest
+
 from cfscanner.speedtest import download
 
 
@@ -27,3 +29,41 @@ def test_download_speed_accepts_integer_server_timing_duration(monkeypatch):
 
     assert speed > 0
     assert latency == 0.046
+
+
+def test_download_speed_test_raises_on_missing_server_timing_header(monkeypatch):
+    """A missing ``Server-Timing`` header must raise ``ValueError``, not ``TypeError``."""
+
+    class Response:
+        headers = {}
+        elapsed = timedelta(milliseconds=50)
+        content = b"x"
+
+    monkeypatch.setattr(download.requests, "get", lambda **kwargs: Response())
+    monkeypatch.setattr(download.time, "perf_counter", iter([10.0, 10.1]).__next__)
+
+    with pytest.raises(ValueError, match="Cannot parse CF header"):
+        download.download_speed_test(
+            n_bytes=1_000,
+            proxies={"https": "socks5://127.0.0.1:12345"},
+            timeout=8,
+        )
+
+
+def test_download_speed_test_raises_on_empty_server_timing_header(monkeypatch):
+    """An empty ``Server-Timing`` header must also raise ``ValueError``."""
+
+    class Response:
+        headers = {"Server-Timing": ""}
+        elapsed = timedelta(milliseconds=50)
+        content = b"x"
+
+    monkeypatch.setattr(download.requests, "get", lambda **kwargs: Response())
+    monkeypatch.setattr(download.time, "perf_counter", iter([10.0, 10.1]).__next__)
+
+    with pytest.raises(ValueError, match="Cannot parse CF header"):
+        download.download_speed_test(
+            n_bytes=1_000,
+            proxies={"https": "socks5://127.0.0.1:12345"},
+            timeout=8,
+        )

--- a/python/tests/test_speedtest_upload.py
+++ b/python/tests/test_speedtest_upload.py
@@ -1,0 +1,61 @@
+import pytest
+
+from cfscanner.speedtest import upload
+
+
+def test_upload_speed_accepts_integer_server_timing_duration(monkeypatch):
+    """Cloudflare emits integer ``dur`` values, not only decimal ones."""
+
+    class Response:
+        headers = {
+            "Server-Timing": (
+                'cfSpeedEdge;dur=4, cfSpeedWorker;dur=28, '
+                'cfL4;desc="?proto=TCP&rtt=0"'
+            )
+        }
+
+    monkeypatch.setattr(upload.requests, "post", lambda **kwargs: Response())
+    monkeypatch.setattr(upload.time, "perf_counter", iter([10.0, 10.1]).__next__)
+
+    speed, latency = upload.upload_speed_test(
+        n_bytes=1_000,
+        proxies={"https": "socks5://127.0.0.1:12345"},
+        timeout=8,
+    )
+
+    assert speed > 0
+    assert latency == pytest.approx(0.096)
+
+
+def test_upload_speed_test_raises_on_missing_server_timing_header(monkeypatch):
+    """A missing ``Server-Timing`` header must raise ``ValueError``, not ``TypeError``."""
+
+    class Response:
+        headers = {}
+
+    monkeypatch.setattr(upload.requests, "post", lambda **kwargs: Response())
+    monkeypatch.setattr(upload.time, "perf_counter", iter([10.0, 10.1]).__next__)
+
+    with pytest.raises(ValueError, match="Cannot parse CF header"):
+        upload.upload_speed_test(
+            n_bytes=1_000,
+            proxies={"https": "socks5://127.0.0.1:12345"},
+            timeout=8,
+        )
+
+
+def test_upload_speed_test_raises_on_empty_server_timing_header(monkeypatch):
+    """An empty ``Server-Timing`` header must also raise ``ValueError``."""
+
+    class Response:
+        headers = {"Server-Timing": ""}
+
+    monkeypatch.setattr(upload.requests, "post", lambda **kwargs: Response())
+    monkeypatch.setattr(upload.time, "perf_counter", iter([10.0, 10.1]).__next__)
+
+    with pytest.raises(ValueError, match="Cannot parse CF header"):
+        upload.upload_speed_test(
+            n_bytes=1_000,
+            proxies={"https": "socks5://127.0.0.1:12345"},
+            timeout=8,
+        )

--- a/python/tests/test_utils_os.py
+++ b/python/tests/test_utils_os.py
@@ -1,0 +1,51 @@
+import pytest
+
+from cfscanner.utils import os as cf_os
+
+
+def test_detect_system_unsupported_system_message_is_interpolated(monkeypatch):
+    """The error message must contain the actual detected system name.
+
+    Regression test for a missing ``f`` prefix that left the message as the
+    literal string ``"Unsupported system: {current_system}"``.
+    """
+    monkeypatch.setattr(cf_os.platform, "system", lambda: "PlanNine")
+    monkeypatch.setattr(cf_os.platform, "machine", lambda: "unknown-arch")
+
+    with pytest.raises(OSError, match="planNine".lower()) as exc_info:
+        cf_os.detect_system()
+
+    assert "{current_system}" not in str(exc_info.value)
+
+
+def test_detect_system_known_systems(monkeypatch):
+    monkeypatch.setattr(cf_os.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(cf_os.platform, "machine", lambda: "x86_64")
+    monkeypatch.delattr(cf_os.sys, "getandroidapilevel", raising=False)
+
+    assert cf_os.detect_system() == ("linux", "64")
+
+
+def test_create_dir_creates_missing_directory(tmp_path):
+    target = tmp_path / "nested" / "dir"
+    assert not target.exists()
+
+    cf_os.create_dir(str(target))
+
+    assert target.is_dir()
+
+
+def test_create_dir_is_noop_when_dir_exists(tmp_path):
+    target = tmp_path / "already-there"
+    target.mkdir()
+
+    cf_os.create_dir(str(target))  # should not raise
+
+    assert target.is_dir()
+
+
+def test_get_n_lines_counts_nonblank_lines(tmp_path):
+    f = tmp_path / "lines.txt"
+    f.write_text("a\n\nb\nc\n\n")
+
+    assert cf_os.get_n_lines(str(f)) == 3

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "cfscanner"
-version = "1.6.0a1"
+version = "1.6.0a2"
 source = { virtual = "." }
 dependencies = [
     { name = "fancylogging" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -19,7 +19,7 @@ wheels = [
 [[package]]
 name = "cfscanner"
 version = "1.6.0a2"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "fancylogging" },
     { name = "pysocks" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "cfscanner"
-version = "1.6.0a2"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "fancylogging" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,0 +1,601 @@
+version = 1
+revision = 3
+requires-python = ">=3.8"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cfscanner"
+version = "1.6.0a1"
+source = { virtual = "." }
+dependencies = [
+    { name = "fancylogging" },
+    { name = "pysocks" },
+    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "rich" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fancylogging", specifier = ">=0.0.3" },
+    { name = "pysocks", specifier = ">=1.7.1" },
+    { name = "requests", specifier = ">=2.28.2" },
+    { name = "rich", specifier = ">=13.7.0,<14.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.16.2" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
+    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
+    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
+    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
+    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4e/3926a1c11f0433791985727965263f788af00db3482d89a7545ca5ecc921/charset_normalizer-3.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84", size = 198599, upload-time = "2025-10-14T04:41:53.213Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7c/b92d1d1dcffc34592e71ea19c882b6709e43d20fa498042dea8b815638d7/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3", size = 143090, upload-time = "2025-10-14T04:41:54.385Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ce/61a28d3bb77281eb24107b937a497f3c43089326d27832a63dcedaab0478/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac", size = 139490, upload-time = "2025-10-14T04:41:55.551Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/bd/c9e59a91b2061c6f8bb98a150670cb16d4cd7c4ba7d11ad0cdf789155f41/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af", size = 155334, upload-time = "2025-10-14T04:41:56.724Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/f17ae176a80f22ff823456af91ba3bc59df308154ff53aef0d39eb3d3419/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2", size = 152823, upload-time = "2025-10-14T04:41:58.236Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/fa/cf5bb2409a385f78750e78c8d2e24780964976acdaaed65dbd6083ae5b40/charset_normalizer-3.4.4-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d", size = 147618, upload-time = "2025-10-14T04:41:59.409Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/63/579784a65bc7de2d4518d40bb8f1870900163e86f17f21fd1384318c459d/charset_normalizer-3.4.4-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3", size = 145516, upload-time = "2025-10-14T04:42:00.579Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a9/94ec6266cd394e8f93a4d69cca651d61bf6ac58d2a0422163b30c698f2c7/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63", size = 145266, upload-time = "2025-10-14T04:42:01.684Z" },
+    { url = "https://files.pythonhosted.org/packages/09/14/d6626eb97764b58c2779fa7928fa7d1a49adb8ce687c2dbba4db003c1939/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7", size = 139559, upload-time = "2025-10-14T04:42:02.902Z" },
+    { url = "https://files.pythonhosted.org/packages/09/01/ddbe6b01313ba191dbb0a43c7563bc770f2448c18127f9ea4b119c44dff0/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4", size = 156653, upload-time = "2025-10-14T04:42:04.005Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c8/d05543378bea89296e9af4510b44c704626e191da447235c8fdedfc5b7b2/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf", size = 145644, upload-time = "2025-10-14T04:42:05.211Z" },
+    { url = "https://files.pythonhosted.org/packages/72/01/2866c4377998ef8a1f6802f6431e774a4c8ebe75b0a6e569ceec55c9cbfb/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074", size = 153964, upload-time = "2025-10-14T04:42:06.341Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/66/66c72468a737b4cbd7851ba2c522fe35c600575fbeac944460b4fd4a06fe/charset_normalizer-3.4.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a", size = 148777, upload-time = "2025-10-14T04:42:07.535Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/d0d56677fdddbffa8ca00ec411f67bb8c947f9876374ddc9d160d4f2c4b3/charset_normalizer-3.4.4-cp38-cp38-win32.whl", hash = "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa", size = 98687, upload-time = "2025-10-14T04:42:08.678Z" },
+    { url = "https://files.pythonhosted.org/packages/00/64/c3bc303d1b586480b1c8e6e1e2191a6d6dd40255244e5cf16763dcec52e6/charset_normalizer-3.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576", size = 106115, upload-time = "2025-10-14T04:42:09.793Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0a/a616d001b3f25647a9068e0b9199f697ce507ec898cacb06a0d5a1617c99/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc", size = 162340, upload-time = "2025-10-14T04:42:14.892Z" },
+    { url = "https://files.pythonhosted.org/packages/85/93/060b52deb249a5450460e0585c88a904a83aec474ab8e7aba787f45e79f2/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e", size = 159619, upload-time = "2025-10-14T04:42:16.676Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/21/0274deb1cc0632cd587a9a0ec6b4674d9108e461cb4cd40d457adaeb0564/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1", size = 153980, upload-time = "2025-10-14T04:42:17.917Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/e3d7d982858dccc11b31906976323d790dded2017a0572f093ff982d692f/charset_normalizer-3.4.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3", size = 152174, upload-time = "2025-10-14T04:42:19.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ff/4a269f8e35f1e58b2df52c131a1fa019acb7ef3f8697b7d464b07e9b492d/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6", size = 151666, upload-time = "2025-10-14T04:42:20.171Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c9/ec39870f0b330d58486001dd8e532c6b9a905f5765f58a6f8204926b4a93/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88", size = 145550, upload-time = "2025-10-14T04:42:21.324Z" },
+    { url = "https://files.pythonhosted.org/packages/75/8f/d186ab99e40e0ed9f82f033d6e49001701c81244d01905dd4a6924191a30/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1", size = 163721, upload-time = "2025-10-14T04:42:22.46Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b1/6047663b9744df26a7e479ac1e77af7134b1fcf9026243bb48ee2d18810f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf", size = 152127, upload-time = "2025-10-14T04:42:23.712Z" },
+    { url = "https://files.pythonhosted.org/packages/59/78/e5a6eac9179f24f704d1be67d08704c3c6ab9f00963963524be27c18ed87/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318", size = 161175, upload-time = "2025-10-14T04:42:24.87Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/0e626e42d54dd2f8dd6fc5e1c5ff00f05fbca17cb699bedead2cae69c62f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c", size = 155375, upload-time = "2025-10-14T04:42:27.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/91/d9615bf2e06f35e4997616ff31248c3657ed649c5ab9d35ea12fce54e380/charset_normalizer-3.4.4-cp39-cp39-win32.whl", hash = "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505", size = 99692, upload-time = "2025-10-14T04:42:28.425Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a9/6c040053909d9d1ef4fcab45fddec083aedc9052c10078339b47c8573ea8/charset_normalizer-3.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966", size = 107192, upload-time = "2025-10-14T04:42:29.482Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c6/4fa536b2c0cd3edfb7ccf8469fa0f363ea67b7213a842b90909ca33dd851/charset_normalizer-3.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50", size = 100220, upload-time = "2025-10-14T04:42:30.632Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or python_full_version >= '3.11'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fancylogging"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-json-logger" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/d3/4b06cdace672c9b69d2d6766e3eecd4b009d9439ecbf4226efe37b09218b/fancylogging-0.0.4.tar.gz", hash = "sha256:d25387bd8f0b475a77a4f1781a717daf91704de57f730ad43da572e35d4892b0", size = 4947, upload-time = "2024-06-13T13:36:18.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/14/9c17b51ea770f1c40801173008c912398432eadf89a0efcbe9b34e5814ba/fancylogging-0.0.4-py3-none-any.whl", hash = "sha256:f7afa8c750e0418c63702d816ca53b0ffcbb0456fe7aa378075c08106f72f681", size = 4453, upload-time = "2024-06-13T13:36:16.635Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging", version = "26.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging", version = "26.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/da/95963cebfc578dabd323d7263958dfb68898617912bb09327dd30e9c8d13/python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c", size = 10508, upload-time = "2023-02-21T17:40:06.209Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd", size = 8067, upload-time = "2023-02-21T17:40:05.117Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
## Summary
- modernizes Python packaging, linting, and error handling
- commits `uv.lock` and adds regression coverage
- fixes Cloudflare integer `Server-Timing` parsing
- prevents generated Xray binaries entering Git
- prepares Python prerelease `1.6.0a2`

## Release readiness
- `uv lock --check` passed
- `uv run pytest -q` — 7 passed
- `uv run ruff check .` passed
- built both sdist and wheel for `1.6.0a2`
- `twine check` passed for both artifacts
- PyPI already contains `1.6.0a1`, so release target is `pyv1.6.0a2`

## Release gate
After an approving review and merge, tag the merged `main` commit as `pyv1.6.0a2`, create the GitHub release, and upload the verified artifacts to PyPI.

`python/test.json` is intentionally excluded as a pre-existing local file.